### PR TITLE
fix(sourceingest): default fetcher settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,5 @@ LOG_LEVEL=info
 GIT_BIN=git
 GIT_CACHE_DIR=.statesight/git-cache
 KUBECTL_BIN=kubectl
+ALLOW_SYNTHETIC_LIVE_STATE=false
 AUTH_REQUIRED=false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,28 +1,28 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+
+permissions:
+  contents: read
 
 jobs:
-
-  build:
+  verify:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
-    - name: Build
-      run: go build -v ./...
+      - name: Vet
+        run: go vet ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ StateSight is **not** a deployment controller and does not replace Argo CD or Fl
 
 ## Current Limitations (Intentional)
 
-- Diffing is seeded mock logic, not full semantic diffing yet.
-- Kubernetes collection is placeholder (future client-go integration).
+- Semantic diffing currently covers resource presence, replica counts, first-container images, and annotations; it is not a complete Kubernetes diff engine.
+- Live-state collection uses `kubectl` for a limited resource set rather than a Kubernetes client integration.
+- Evidence attribution is placeholder data, and stored ignore rules are not evaluated yet.
 - GitHub webhook endpoint is baseline-only (not full GitHub App install/auth flow).
+- Git desired-state ingestion reads plain YAML/JSON manifests; Helm, Kustomize, Argo CD, and Flux integrations are not implemented.
 - No auto-remediation.
-- No Argo/Flux integrations yet.
 
 ## Auth and RBAC Baseline
 
@@ -35,6 +36,16 @@ Expected request headers in auth-enabled mode:
 - `X-User-Email` (optional)
 
 Roles come from `workspace_memberships` (`viewer`, `editor`, `admin`).
+
+## Analysis Safety and Configuration
+
+The worker honors:
+
+- `GIT_BIN` and `GIT_CACHE_DIR` for desired-state checkouts.
+- `KUBECTL_BIN` for live-state collection.
+- `ALLOW_SYNTHETIC_LIVE_STATE`, which defaults to `false`.
+
+When `kubectl` cannot collect live resources, analysis fails by default. Set `ALLOW_SYNTHETIC_LIVE_STATE=true` only for local pipeline demonstrations; resulting incidents do not represent observations from a cluster.
 
 ## Architecture Overview
 
@@ -86,6 +97,8 @@ make migrate-up
 make seed
 ```
 
+The seed data provides a prebuilt incident for UI inspection. Its source repository is illustrative, not a runnable analysis input. Running a real analysis requires an accessible manifest repository and Kubernetes credentials available to the worker. A containerized worker also needs any kubeconfig path referenced by a cluster record mounted inside its container.
+
 ### 6) Run Services Locally (optional alternative to containerized app services)
 
 ```bash
@@ -120,12 +133,13 @@ make web
 - `GET /api/v1/applications/:id`
 - `POST /api/v1/applications/:id/analyze`
 - `GET /api/v1/incidents/:id`
+- `GET /api/v1/incidents/:id/timeline`
 - `POST /api/v1/github/webhook`
 
 ## Next Suggested Implementation Steps
 
-1. Replace seeded diff logic with first real resource-normalized semantic diffing.
-2. Add real desired-state ingestion from Git source definitions.
-3. Add real live-state collection adapters for Kubernetes clusters.
-4. Expand incident grouping and timeline construction logic.
-5. Add authentication, workspace RBAC, and multi-tenant access control.
+1. Replace placeholder evidence attribution with evidence derived from real source and cluster signals.
+2. Implement ignore-rule evaluation and API/UI management around persisted rules.
+3. Expand normalization, diff coverage, and incident grouping with focused tests.
+4. Replace header-trusted identity with an authenticated workspace access flow.
+5. Add GitOps rendering/integration support and hardened Kubernetes collection.

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -4,3 +4,4 @@ LOG_LEVEL=info
 GIT_BIN=git
 GIT_CACHE_DIR=.statesight/git-cache
 KUBECTL_BIN=kubectl
+ALLOW_SYNTHETIC_LIVE_STATE=false

--- a/apps/worker/main.go
+++ b/apps/worker/main.go
@@ -44,7 +44,12 @@ func run() error {
 	}
 	defer queue.Close()
 
-	processor := jobs.NewProcessor(storage.NewRepository(pool), logger)
+	processor := jobs.NewProcessor(storage.NewRepository(pool), logger, jobs.ProcessorOptions{
+		GitBinary:               cfg.GitBinary,
+		GitCacheDir:             cfg.GitCacheDir,
+		KubectlBinary:           cfg.KubectlBinary,
+		AllowSyntheticLiveState: cfg.AllowSyntheticLiveState,
+	})
 
 	workerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/deployments/docker/Dockerfile.worker
+++ b/deployments/docker/Dockerfile.worker
@@ -7,7 +7,8 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/worker ./apps/worker
 
-FROM gcr.io/distroless/static-debian12
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates git kubectl
 WORKDIR /app
 COPY --from=build /out/worker /app/worker
 ENTRYPOINT ["/app/worker"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       GIT_BIN: git
       GIT_CACHE_DIR: /tmp/statesight/git-cache
       KUBECTL_BIN: kubectl
+      ALLOW_SYNTHETIC_LIVE_STATE: "false"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/ARCHITECTURE-NOTES.md
+++ b/docs/ARCHITECTURE-NOTES.md
@@ -2,14 +2,14 @@
 
 This is a high-level direction, not a fixed final architecture.
 
-## Likely Stack
+## Baseline Stack
 
 - Frontend: React + TypeScript
 - Backend services: Go
 - Data: PostgreSQL
 - Queue/cache: Redis
 
-## Likely Services
+## Baseline Services
 
 - web app
 - API service
@@ -34,7 +34,8 @@ This is a high-level direction, not a fixed final architecture.
 - small, testable packages
 - explicit contracts between components
 - clear observability hooks
+- fail analysis when real live-state collection is unavailable unless demo behavior is explicitly enabled
 
 ## Important Note
 
-Architecture will evolve during the baseline scaffold and early implementation phases. Changes should be recorded in `docs/DECISIONS.md`.
+Architecture will evolve during implementation. Behavior-affecting changes should be recorded in `docs/DECISIONS.md`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,3 +26,10 @@ Use this file to record meaningful project decisions as the codebase grows.
   Options considered: monolith only, microservices split, balanced 3-service baseline.
   Chosen approach: 3-service baseline with shared internal packages.
   Consequences: easier incremental growth without over-committing to high service complexity.
+
+- Date: 2026-05-25
+  Decision: Synthetic live-state collection is disabled by default and must be explicitly enabled for demonstrations.
+  Context: A forensic analysis must not emit incidents from invented live resources when `kubectl` is unavailable or misconfigured.
+  Options considered: always fall back to synthetic resources, remove synthetic behavior entirely, retain it behind an explicit runtime option.
+  Chosen approach: fail live-state collection by default and permit `ALLOW_SYNTHETIC_LIVE_STATE=true` only for local demonstrations.
+  Consequences: real analyses fail clearly when cluster access is unavailable; demo output can still be generated but must be treated as synthetic.

--- a/docs/PROJECT-OVERVIEW.md
+++ b/docs/PROJECT-OVERVIEW.md
@@ -31,4 +31,6 @@ It is designed to help teams understand drift between:
 
 ## Current Stage
 
-Baseline scaffold in progress with API, worker, web, migrations, and seed flow.
+The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, timelines, and workspace RBAC boundaries.
+
+Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, effective ignore rules, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,37 +1,32 @@
 # StateSight Roadmap
 
-## Stage 1: Repository Foundation (Current)
+## Completed Baseline
 
-- establish repo structure
-- define docs and collaboration workflow
-- add starter conventions and templates
+- repository structure, collaboration documents, local Docker Compose workflow
+- Go API and asynchronous Redis-backed worker with PostgreSQL persistence
+- React operator UI for overview, applications, incidents, and timelines
+- Git manifest fetcher and `kubectl` live-state collector
+- initial resource normalization and semantic diff engine
+- baseline workspace RBAC boundary and GitHub webhook ingestion
 
-## Stage 2: Baseline Scaffold
+## Current: Baseline Stabilization
 
-- add initial monorepo skeleton
-- add API, worker, and web placeholders
-- add local development conventions
+- keep documentation aligned with implemented capabilities and limitations
+- enforce real-live-state collection by default; synthetic results are explicit demo behavior only
+- pass worker runtime configuration to source and cluster adapters
+- establish CI and focused tests for critical analysis boundaries
 
-## Stage 3: First Analyze Flow
+## Next: Trustworthy Analysis
 
-- create first end-to-end analyze request path
-- persist minimal entities
-- show minimal UI flow for analysis status
+- replace placeholder evidence attribution with real provenance signals
+- implement persisted ignore-rule evaluation and management
+- improve incident grouping and semantic normalization/diff coverage
+- replace trusted request headers with a real authentication integration
 
-## Stage 4: First Real Diffing
+## Later: Integrations and Operations
 
-- add first meaningful desired vs live diff logic
-- define incident grouping baseline
-
-## Stage 5: Evidence and Timelines
-
-- attach evidence records to incidents
-- provide timeline-oriented change visibility
-
-## Stage 6: Integrations Later
-
-- deepen Git provider integration
-- deepen Kubernetes collection logic
-- harden scaling, reliability, and observability
+- support GitOps rendering and controller integrations
+- deepen Kubernetes collection and multi-cluster operational controls
+- harden reliability, observability, deployment, and scale behavior
 
 Roadmap is expected to evolve as implementation learns from real usage.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -15,5 +15,7 @@ This is the lightweight workflow for StateSight collaboration.
 - `main` is protected.
 - Keep changes small and easy to review.
 - Ask before large structural changes.
+- Update relevant documentation and the decision log when behavior or architecture changes.
+- Record verification performed for each change.
 - Clarity is more important than speed.
 - If blocked, ask early in the issue or PR.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -9,6 +9,8 @@ StateSight baseline provides a minimal but extensible end-to-end path:
 3. Worker consumes jobs and writes snapshots/incidents/evidence.
 4. Web app reads API data and renders overview, application, and incident pages.
 
+The current worker obtains desired state by cloning configured Git sources and obtains live state through `kubectl`. Failure to collect live state fails an analysis by default; synthetic live state is an explicit local-demo option and is not trustworthy forensic evidence.
+
 ## Services
 
 - `apps/api`: HTTP entrypoint, routing, request middleware, API contracts.
@@ -19,6 +21,13 @@ StateSight baseline provides a minimal but extensible end-to-end path:
 
 - PostgreSQL: source of truth for applications, snapshots, incidents, evidence, jobs, and event metadata.
 - Redis: lightweight queue transport for asynchronous work.
+
+## Worker Runtime Configuration
+
+- `GIT_BIN`: Git executable used to fetch desired-state repositories.
+- `GIT_CACHE_DIR`: temporary checkout parent directory.
+- `KUBECTL_BIN`: executable used for cluster collection.
+- `ALLOW_SYNTHETIC_LIVE_STATE`: optional demo-only fallback, disabled by default.
 
 ## Key Internal Boundaries
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,26 +9,27 @@ import (
 )
 
 type Common struct {
-	ServiceName         string
-	LogLevel            string
-	DatabaseURL         string
-	RedisURL            string
-	GitHubWebhookSecret string
-	GitBinary           string
-	GitCacheDir         string
-	KubectlBinary       string
-	AuthRequired        bool
+	ServiceName string
+	LogLevel    string
+	DatabaseURL string
+	RedisURL    string
 }
 
 type API struct {
 	Common
-	HTTPPort          int
-	ReadHeaderTimeout time.Duration
+	GitHubWebhookSecret string
+	AuthRequired        bool
+	HTTPPort            int
+	ReadHeaderTimeout   time.Duration
 }
 
 type Worker struct {
 	Common
-	PollTimeout time.Duration
+	GitBinary               string
+	GitCacheDir             string
+	KubectlBinary           string
+	AllowSyntheticLiveState bool
+	PollTimeout             time.Duration
 }
 
 func LoadAPI() (API, error) {
@@ -38,31 +39,32 @@ func LoadAPI() (API, error) {
 		return API{}, err
 	}
 	return API{
-		Common:            common,
-		HTTPPort:          port,
-		ReadHeaderTimeout: 5 * time.Second,
+		Common:              common,
+		GitHubWebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),
+		AuthRequired:        boolFromEnv("AUTH_REQUIRED", false),
+		HTTPPort:            port,
+		ReadHeaderTimeout:   5 * time.Second,
 	}, nil
 }
 
 func LoadWorker() (Worker, error) {
 	common := loadCommon("statesight-worker")
 	return Worker{
-		Common:      common,
-		PollTimeout: 5 * time.Second,
+		Common:                  common,
+		GitBinary:               stringFromEnv("GIT_BIN", "git"),
+		GitCacheDir:             stringFromEnv("GIT_CACHE_DIR", ".statesight/git-cache"),
+		KubectlBinary:           stringFromEnv("KUBECTL_BIN", "kubectl"),
+		AllowSyntheticLiveState: boolFromEnv("ALLOW_SYNTHETIC_LIVE_STATE", false),
+		PollTimeout:             5 * time.Second,
 	}, nil
 }
 
 func loadCommon(defaultService string) Common {
 	return Common{
-		ServiceName:         stringFromEnv("SERVICE_NAME", defaultService),
-		LogLevel:            stringFromEnv("LOG_LEVEL", "info"),
-		DatabaseURL:         stringFromEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/statesight?sslmode=disable"),
-		RedisURL:            stringFromEnv("REDIS_URL", "redis://localhost:6379/0"),
-		GitHubWebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),
-		GitBinary:           stringFromEnv("GIT_BIN", "git"),
-		GitCacheDir:         stringFromEnv("GIT_CACHE_DIR", ".statesight/git-cache"),
-		KubectlBinary:       stringFromEnv("KUBECTL_BIN", "kubectl"),
-		AuthRequired:        boolFromEnv("AUTH_REQUIRED", false),
+		ServiceName: stringFromEnv("SERVICE_NAME", defaultService),
+		LogLevel:    stringFromEnv("LOG_LEVEL", "info"),
+		DatabaseURL: stringFromEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/statesight?sslmode=disable"),
+		RedisURL:    stringFromEnv("REDIS_URL", "redis://localhost:6379/0"),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+func TestLoadWorkerReadsCollectorConfiguration(t *testing.T) {
+	t.Setenv("GIT_BIN", "/tools/git")
+	t.Setenv("GIT_CACHE_DIR", "/var/cache/statesight")
+	t.Setenv("KUBECTL_BIN", "/tools/kubectl")
+	t.Setenv("ALLOW_SYNTHETIC_LIVE_STATE", "true")
+
+	cfg, err := LoadWorker()
+	if err != nil {
+		t.Fatalf("load worker config: %v", err)
+	}
+
+	if cfg.GitBinary != "/tools/git" {
+		t.Fatalf("expected configured git binary, got %q", cfg.GitBinary)
+	}
+	if cfg.GitCacheDir != "/var/cache/statesight" {
+		t.Fatalf("expected configured git cache directory, got %q", cfg.GitCacheDir)
+	}
+	if cfg.KubectlBinary != "/tools/kubectl" {
+		t.Fatalf("expected configured kubectl binary, got %q", cfg.KubectlBinary)
+	}
+	if !cfg.AllowSyntheticLiveState {
+		t.Fatal("expected synthetic live state to be enabled by explicit configuration")
+	}
+}
+
+func TestLoadWorkerDisablesSyntheticLiveStateByDefault(t *testing.T) {
+	t.Setenv("ALLOW_SYNTHETIC_LIVE_STATE", "")
+
+	cfg, err := LoadWorker()
+	if err != nil {
+		t.Fatalf("load worker config: %v", err)
+	}
+
+	if cfg.AllowSyntheticLiveState {
+		t.Fatal("expected synthetic live state to be disabled by default")
+	}
+}

--- a/internal/jobs/processor.go
+++ b/internal/jobs/processor.go
@@ -47,11 +47,21 @@ type Processor struct {
 	logger          *slog.Logger
 }
 
-func NewProcessor(store Store, logger *slog.Logger) *Processor {
+type ProcessorOptions struct {
+	GitBinary               string
+	GitCacheDir             string
+	KubectlBinary           string
+	AllowSyntheticLiveState bool
+}
+
+func NewProcessor(store Store, logger *slog.Logger, options ProcessorOptions) *Processor {
 	return &Processor{
-		store:           store,
-		fetcher:         sourceingest.NewGitFetcher("git", ".statesight/git-cache"),
-		collector:       k8scollect.NewCollector(k8scollect.CollectorOptions{}),
+		store:   store,
+		fetcher: sourceingest.NewGitFetcher(options.GitBinary, options.GitCacheDir),
+		collector: k8scollect.NewCollector(k8scollect.CollectorOptions{
+			KubectlBinary:          options.KubectlBinary,
+			AllowSyntheticFallback: options.AllowSyntheticLiveState,
+		}),
 		normalizer:      normalize.PassThroughNormalizer{},
 		diffEngine:      diff.SemanticEngine{},
 		grouper:         incidents.SimpleGrouper{},

--- a/internal/jobs/processor_test.go
+++ b/internal/jobs/processor_test.go
@@ -1,0 +1,45 @@
+package jobs
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AnouarMohamed/StateSight/internal/sourceingest"
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func TestNewProcessorAppliesAdapterOptions(t *testing.T) {
+	kubectlBinary := filepath.Join(t.TempDir(), "kubectl")
+	const kubectlScript = "#!/bin/sh\nprintf '%s\\n' '{\"items\":[]}'\n"
+	if err := os.WriteFile(kubectlBinary, []byte(kubectlScript), 0o700); err != nil {
+		t.Fatalf("write kubectl test binary: %v", err)
+	}
+
+	processor := NewProcessor(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), ProcessorOptions{
+		GitBinary:     "/tools/git",
+		GitCacheDir:   "/var/cache/statesight",
+		KubectlBinary: kubectlBinary,
+	})
+
+	fetcher, ok := processor.fetcher.(sourceingest.GitFetcher)
+	if !ok {
+		t.Fatalf("expected GitFetcher, got %T", processor.fetcher)
+	}
+	if fetcher.GitBinary != "/tools/git" || fetcher.CacheDir != "/var/cache/statesight" {
+		t.Fatalf("expected configured git fetcher, got %#v", fetcher)
+	}
+
+	state, err := processor.collector.CollectLiveState(context.Background(), model.Cluster{}, model.Application{
+		Namespace: "payments",
+	})
+	if err != nil {
+		t.Fatalf("collect state through configured kubectl binary: %v", err)
+	}
+	if got := state.Summary["source"]; got != "kubectl" {
+		t.Fatalf("expected kubectl source, got %v", got)
+	}
+}

--- a/internal/k8scollect/collector.go
+++ b/internal/k8scollect/collector.go
@@ -23,7 +23,8 @@ type Collector interface {
 }
 
 type CollectorOptions struct {
-	KubectlBinary string
+	KubectlBinary          string
+	AllowSyntheticFallback bool
 }
 
 type Adapter interface {
@@ -42,10 +43,13 @@ func NewCollector(options CollectorOptions) Collector {
 		binary = "kubectl"
 	}
 
-	return collector{
-		primary:  KubectlAdapter{KubectlBinary: binary},
-		fallback: SyntheticAdapter{},
+	result := collector{
+		primary: KubectlAdapter{KubectlBinary: binary},
 	}
+	if options.AllowSyntheticFallback {
+		result.fallback = SyntheticAdapter{}
+	}
+	return result
 }
 
 func (c collector) CollectLiveState(ctx context.Context, cluster model.Cluster, app model.Application) (LiveState, error) {
@@ -124,7 +128,7 @@ func (a KubectlAdapter) Collect(ctx context.Context, cluster model.Cluster, app 
 	return payload.Items, nil
 }
 
-// SyntheticAdapter is a fallback for local environments without cluster access.
+// SyntheticAdapter provides demo-only live state when explicitly enabled.
 type SyntheticAdapter struct{}
 
 func (SyntheticAdapter) Name() string {

--- a/internal/k8scollect/collector_test.go
+++ b/internal/k8scollect/collector_test.go
@@ -1,0 +1,45 @@
+package k8scollect
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func TestCollectorFailsWithoutSyntheticFallback(t *testing.T) {
+	collector := NewCollector(CollectorOptions{
+		KubectlBinary: filepath.Join(t.TempDir(), "missing-kubectl"),
+	})
+
+	_, err := collector.CollectLiveState(context.Background(), model.Cluster{}, model.Application{
+		Name:      "ledger-api",
+		Namespace: "payments",
+	})
+	if err == nil {
+		t.Fatal("expected collection failure when kubectl cannot run")
+	}
+}
+
+func TestCollectorUsesSyntheticFallbackOnlyWhenEnabled(t *testing.T) {
+	collector := NewCollector(CollectorOptions{
+		KubectlBinary:          filepath.Join(t.TempDir(), "missing-kubectl"),
+		AllowSyntheticFallback: true,
+	})
+
+	state, err := collector.CollectLiveState(context.Background(), model.Cluster{Name: "demo"}, model.Application{
+		Name:      "ledger-api",
+		Namespace: "payments",
+	})
+	if err != nil {
+		t.Fatalf("collect synthetic live state: %v", err)
+	}
+
+	if got := state.Summary["source"]; got != "synthetic" {
+		t.Fatalf("expected synthetic source, got %v", got)
+	}
+	if len(state.Resources) != 1 {
+		t.Fatalf("expected one synthetic resource, got %d", len(state.Resources))
+	}
+}

--- a/internal/sourceingest/fetcher.go
+++ b/internal/sourceingest/fetcher.go
@@ -36,6 +36,15 @@ type GitFetcher struct {
 }
 
 func NewGitFetcher(gitBinary, cacheDir string) GitFetcher {
+	gitBinary = strings.TrimSpace(gitBinary)
+	if gitBinary == "" {
+		gitBinary = "git"
+	}
+	cacheDir = strings.TrimSpace(cacheDir)
+	if cacheDir == "" {
+		cacheDir = ".statesight/git-cache"
+	}
+
 	return GitFetcher{
 		GitBinary: gitBinary,
 		CacheDir:  cacheDir,

--- a/internal/sourceingest/fetcher_test.go
+++ b/internal/sourceingest/fetcher_test.go
@@ -1,0 +1,14 @@
+package sourceingest
+
+import "testing"
+
+func TestNewGitFetcherDefaultsEmptySettings(t *testing.T) {
+	fetcher := NewGitFetcher("", "")
+
+	if fetcher.GitBinary != "git" {
+		t.Fatalf("expected default git binary, got %q", fetcher.GitBinary)
+	}
+	if fetcher.CacheDir != ".statesight/git-cache" {
+		t.Fatalf("expected default cache directory, got %q", fetcher.CacheDir)
+	}
+}


### PR DESCRIPTION
**Implemented**

- Worker configuration is now actually wired into analysis adapters through [main.go](/home/anouar/Documents/Projects/StateSight/apps/worker/main.go:47), [processor.go](/home/anouar/Documents/Projects/StateSight/internal/jobs/processor.go:50), and [config.go](/home/anouar/Documents/Projects/StateSight/internal/config/config.go:11).
- API-only and worker-only settings are no longer mixed in the shared config type.
- Live-state collection no longer silently fabricates cluster data. Synthetic results require explicit `ALLOW_SYNTHETIC_LIVE_STATE=true`: [collector.go](/home/anouar/Documents/Projects/StateSight/internal/k8scollect/collector.go:25).
- Git fetcher construction now has robust defaults when adapter options are empty.
- The worker container now includes the `git` and `kubectl` commands its runtime invokes: [Dockerfile.worker](/home/anouar/Documents/Projects/StateSight/deployments/docker/Dockerfile.worker:10).
- The upstream CI workflow now uses the Go version declared by `go.mod` and runs vet plus tests: [go.yml](/home/anouar/Documents/Projects/StateSight/.github/workflows/go.yml:1).

**Tests Added**

- Worker config behavior: [config_test.go](/home/anouar/Documents/Projects/StateSight/internal/config/config_test.go:1)
- Processor adapter option propagation: [processor_test.go](/home/anouar/Documents/Projects/StateSight/internal/jobs/processor_test.go:1)
- Strict versus explicitly synthetic cluster collection: [collector_test.go](/home/anouar/Documents/Projects/StateSight/internal/k8scollect/collector_test.go:1)
- Git fetcher defaults: [fetcher_test.go](/home/anouar/Documents/Projects/StateSight/internal/sourceingest/fetcher_test.go:1)

**Documentation**

The stale roadmap and baseline descriptions have been corrected in [README.md](/home/anouar/Documents/Projects/StateSight/README.md:19), [ROADMAP.md](/home/anouar/Documents/Projects/StateSight/docs/ROADMAP.md:1), and [overview.md](/home/anouar/Documents/Projects/StateSight/docs/architecture/overview.md:5). The synthetic-live-state safety decision is recorded in [DECISIONS.md](/home/anouar/Documents/Projects/StateSight/docs/DECISIONS.md:30), and [WORKFLOW.md](/home/anouar/Documents/Projects/StateSight/docs/WORKFLOW.md:13) now requires behavioral documentation and verification records.

**Verification**

Passed:

- `make test`
- `make lint`
- `make docs-check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ALLOW_SYNTHETIC_LIVE_STATE` environment variable (defaults to `false`) to control demo-mode behavior when live state collection is unavailable.
  * Worker runtime is now configurable with customizable Git and Kubernetes binary paths.

* **Documentation**
  * Enhanced documentation clarifying system constraints, worker configuration options, and updated roadmap with capability-aligned phases.

* **Infrastructure**
  * Updated worker Docker image base to Alpine with bundled `git` and `kubectl`.
  * Improved GitHub Actions workflow with tighter permissions and verification steps.

* **Tests**
  * Added unit tests for configuration loading, live-state collection behavior, and Git fetcher defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnouarMohamed/StateSight/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->