### PR TITLE
feat(ignorerules): evaluate active field path rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ StateSight is **not** a deployment controller and does not replace Argo CD or Fl
 
 - Semantic diffing currently covers resource presence, replica counts, first-container images, and annotations; it is not a complete Kubernetes diff engine.
 - Live-state collection uses `kubectl` for a limited resource set rather than a Kubernetes client integration.
-- Evidence attribution is placeholder data, and stored ignore rules are not evaluated yet.
+- Evidence attribution is placeholder data; ignore rules currently support exact field-path suppression only.
 - GitHub webhook endpoint is baseline-only (not full GitHub App install/auth flow).
 - Git desired-state ingestion reads plain YAML/JSON manifests; Helm, Kustomize, Argo CD, and Flux integrations are not implemented.
 - No auto-remediation.
@@ -46,6 +46,20 @@ The worker honors:
 - `ALLOW_SYNTHETIC_LIVE_STATE`, which defaults to `false`.
 
 When `kubectl` cannot collect live resources, analysis fails by default. Set `ALLOW_SYNTHETIC_LIVE_STATE=true` only for local pipeline demonstrations; resulting incidents do not represent observations from a cluster.
+
+## Ignore Rule Baseline
+
+Active `ignore_rules` rows apply within their workspace during analysis. For the current baseline, `match_expression` is one exact drift field path, such as:
+
+- `spec.replicas`
+- `spec.template.spec.containers[0].image`
+- `metadata.annotations.example.com/managed-by`
+
+Matching is case-sensitive and trims surrounding whitespace. Wildcards and regular expressions are not supported. If multiple active rules match one field path, the oldest rule is used first. A suppressed candidate does not create a drift incident; the worker records the matching rule in its structured logs.
+
+Rules currently have no application or resource selector: a matching field path is suppressed across the entire workspace. Use this baseline only for fields the workspace intentionally manages outside desired state.
+
+Rule management API and UI surfaces are not implemented yet; persisted rules must currently be administered through the database.
 
 ## Architecture Overview
 
@@ -139,7 +153,7 @@ make web
 ## Next Suggested Implementation Steps
 
 1. Replace placeholder evidence attribution with evidence derived from real source and cluster signals.
-2. Implement ignore-rule evaluation and API/UI management around persisted rules.
+2. Add ignore-rule API/UI management, richer scoping, and persisted suppression audit records.
 3. Expand normalization, diff coverage, and incident grouping with focused tests.
 4. Replace header-trusted identity with an authenticated workspace access flow.
 5. Add GitOps rendering/integration support and hardened Kubernetes collection.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -33,3 +33,10 @@ Use this file to record meaningful project decisions as the codebase grows.
   Options considered: always fall back to synthetic resources, remove synthetic behavior entirely, retain it behind an explicit runtime option.
   Chosen approach: fail live-state collection by default and permit `ALLOW_SYNTHETIC_LIVE_STATE=true` only for local demonstrations.
   Consequences: real analyses fail clearly when cluster access is unavailable; demo output can still be generated but must be treated as synthetic.
+
+- Date: 2026-05-25
+  Decision: Initial ignore-rule evaluation supports exact field-path matching within a workspace.
+  Context: The schema contains persisted ignore rules, but the worker previously ignored them. A broad or implicit expression language would make suppression difficult to reason about before rule-management and audit surfaces exist.
+  Options considered: keep rules inactive until UI work, interpret expressions as glob or regular-expression patterns, implement exact field-path matching first.
+  Chosen approach: load active rules for an application's workspace and suppress only candidates whose canonical field path exactly matches `match_expression`.
+  Consequences: common known-noise fields can be suppressed deterministically across a workspace; resource-specific matching, wildcard matching, management endpoints, and persisted suppression audit records remain future work.

--- a/docs/PROJECT-OVERVIEW.md
+++ b/docs/PROJECT-OVERVIEW.md
@@ -33,4 +33,4 @@ It is designed to help teams understand drift between:
 
 The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, timelines, and workspace RBAC boundaries.
 
-Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, effective ignore rules, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.
+Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, managed and auditable ignore rules, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,12 +14,13 @@
 - keep documentation aligned with implemented capabilities and limitations
 - enforce real-live-state collection by default; synthetic results are explicit demo behavior only
 - pass worker runtime configuration to source and cluster adapters
+- execute active workspace ignore rules for exact drift field-path matches
 - establish CI and focused tests for critical analysis boundaries
 
 ## Next: Trustworthy Analysis
 
 - replace placeholder evidence attribution with real provenance signals
-- implement persisted ignore-rule evaluation and management
+- add ignore-rule management APIs/UI, richer match scopes, and persisted suppression audit records
 - improve incident grouping and semantic normalization/diff coverage
 - replace trusted request headers with a real authentication integration
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -29,6 +29,14 @@ The current worker obtains desired state by cloning configured Git sources and o
 - `KUBECTL_BIN`: executable used for cluster collection.
 - `ALLOW_SYNTHETIC_LIVE_STATE`: optional demo-only fallback, disabled by default.
 
+## Ignore-Rule Evaluation
+
+- The worker loads active rules for the application's workspace only when an analysis produces drift candidates.
+- Each baseline `match_expression` is an exact, case-sensitive drift field path after trimming surrounding whitespace.
+- A rule applies to that field path across its workspace; resource- or application-specific selectors are not supported yet.
+- Rules are considered in creation order, with ID as a deterministic tie-breaker; the first match suppresses incident creation for that candidate.
+- Suppressed candidates are currently reported in worker logs. Persisted suppression auditing and rule-management APIs are future work.
+
 ## Key Internal Boundaries
 
 - `internal/sourceingest`: desired-state ingestion boundary.

--- a/internal/ignorerules/evaluator.go
+++ b/internal/ignorerules/evaluator.go
@@ -1,15 +1,33 @@
 package ignorerules
 
-import "context"
+import (
+	"strings"
 
-// Evaluator determines if a candidate should be suppressed.
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+// Evaluator identifies the first persisted rule that suppresses a drift field.
 type Evaluator interface {
-	ShouldIgnore(ctx context.Context, applicationID, fieldPath string) (bool, string, error)
+	FindMatch(rules []model.IgnoreRule, fieldPath string) (model.IgnoreRule, bool)
 }
 
-// NoopEvaluator keeps all findings visible until ignore rules are implemented.
-type NoopEvaluator struct{}
+// ExactFieldPathEvaluator matches a rule expression to one canonical drift field path.
+type ExactFieldPathEvaluator struct{}
 
-func (NoopEvaluator) ShouldIgnore(_ context.Context, _ string, _ string) (bool, string, error) {
-	return false, "", nil
+func (ExactFieldPathEvaluator) FindMatch(rules []model.IgnoreRule, fieldPath string) (model.IgnoreRule, bool) {
+	fieldPath = strings.TrimSpace(fieldPath)
+	if fieldPath == "" {
+		return model.IgnoreRule{}, false
+	}
+
+	for _, rule := range rules {
+		if !rule.Active {
+			continue
+		}
+		if strings.TrimSpace(rule.MatchExpression) == fieldPath {
+			return rule, true
+		}
+	}
+
+	return model.IgnoreRule{}, false
 }

--- a/internal/ignorerules/evaluator_test.go
+++ b/internal/ignorerules/evaluator_test.go
@@ -1,0 +1,35 @@
+package ignorerules
+
+import (
+	"testing"
+
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func TestExactFieldPathEvaluatorFindMatch(t *testing.T) {
+	evaluator := ExactFieldPathEvaluator{}
+	rules := []model.IgnoreRule{
+		{ID: "inactive", MatchExpression: "spec.replicas", Active: false},
+		{ID: "wildcard-looking", MatchExpression: "spec.*", Active: true},
+		{ID: "replicas", MatchExpression: " spec.replicas ", Active: true},
+		{ID: "later-replicas", MatchExpression: "spec.replicas", Active: true},
+	}
+
+	rule, matched := evaluator.FindMatch(rules, "spec.replicas")
+	if !matched {
+		t.Fatal("expected exact field path match")
+	}
+	if rule.ID != "replicas" {
+		t.Fatalf("expected first active exact match, got %q", rule.ID)
+	}
+}
+
+func TestExactFieldPathEvaluatorRejectsPartialMatch(t *testing.T) {
+	evaluator := ExactFieldPathEvaluator{}
+	rules := []model.IgnoreRule{{ID: "annotation", MatchExpression: "metadata.annotations", Active: true}}
+
+	_, matched := evaluator.FindMatch(rules, "metadata.annotations.rollout")
+	if matched {
+		t.Fatal("expected partial expression not to suppress a field")
+	}
+}

--- a/internal/jobs/processor.go
+++ b/internal/jobs/processor.go
@@ -26,6 +26,7 @@ type Store interface {
 	GetApplicationByID(ctx context.Context, id string) (model.Application, error)
 	GetSourceDefinitionByID(ctx context.Context, id string) (model.SourceDefinition, error)
 	GetClusterByID(ctx context.Context, id string) (model.Cluster, error)
+	ListActiveIgnoreRulesByWorkspace(ctx context.Context, workspaceID string) ([]model.IgnoreRule, error)
 	CreateDesiredSnapshot(ctx context.Context, params storage.CreateDesiredSnapshotParams) (model.DesiredSnapshot, error)
 	CreateLiveSnapshot(ctx context.Context, params storage.CreateLiveSnapshotParams) (model.LiveSnapshot, error)
 	CreateIncident(ctx context.Context, params storage.CreateIncidentParams) (model.DriftIncident, error)
@@ -67,7 +68,7 @@ func NewProcessor(store Store, logger *slog.Logger, options ProcessorOptions) *P
 		grouper:         incidents.SimpleGrouper{},
 		attributor:      evidence.MockAttributor{},
 		recommendation:  scoring.RuleBasedRecommendation{},
-		ignoreEvaluator: ignorerules.NoopEvaluator{},
+		ignoreEvaluator: ignorerules.ExactFieldPathEvaluator{},
 		logger:          logger,
 	}
 }
@@ -177,13 +178,25 @@ func (p *Processor) processAnalyze(ctx context.Context, msg Message) error {
 		return fmt.Errorf("group incidents: %w", err)
 	}
 
-	for _, candidate := range candidates {
-		ignored, reason, err := p.ignoreEvaluator.ShouldIgnore(ctx, app.ID, candidate.FieldPath)
+	var rules []model.IgnoreRule
+	if len(candidates) > 0 {
+		rules, err = p.store.ListActiveIgnoreRulesByWorkspace(ctx, app.WorkspaceID)
 		if err != nil {
-			return fmt.Errorf("evaluate ignore rule: %w", err)
+			return fmt.Errorf("list active ignore rules: %w", err)
 		}
+	}
+
+	for _, candidate := range candidates {
+		rule, ignored := p.ignoreEvaluator.FindMatch(rules, candidate.FieldPath)
 		if ignored {
-			p.logger.Info("candidate ignored by rule", "application_id", app.ID, "field_path", candidate.FieldPath, "reason", reason)
+			p.logger.Info(
+				"candidate ignored by rule",
+				"application_id", app.ID,
+				"field_path", candidate.FieldPath,
+				"ignore_rule_id", rule.ID,
+				"ignore_rule_name", rule.Name,
+				"reason", rule.Reason,
+			)
 			continue
 		}
 

--- a/internal/jobs/processor_ignore_rules_test.go
+++ b/internal/jobs/processor_ignore_rules_test.go
@@ -1,0 +1,176 @@
+package jobs
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/AnouarMohamed/StateSight/internal/k8scollect"
+	"github.com/AnouarMohamed/StateSight/internal/sourceingest"
+	"github.com/AnouarMohamed/StateSight/internal/storage"
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func TestProcessAnalyzeSuppressesCandidateMatchingWorkspaceIgnoreRule(t *testing.T) {
+	store := &ignoreRuleAnalysisStore{
+		app: model.Application{
+			ID:                 "application-1",
+			WorkspaceID:        "workspace-1",
+			SourceDefinitionID: "source-1",
+			ClusterID:          "cluster-1",
+			Name:               "ledger-api",
+			Namespace:          "payments",
+		},
+		rules: []model.IgnoreRule{{
+			ID:              "rule-1",
+			Name:            "Allow HPA replica variance",
+			MatchExpression: "spec.replicas",
+			Reason:          "replicas are managed outside Git",
+			Active:          true,
+		}},
+	}
+
+	processor := NewProcessor(store, slog.New(slog.NewTextHandler(io.Discard, nil)), ProcessorOptions{})
+	processor.fetcher = staticDesiredStateFetcher{}
+	processor.collector = staticLiveStateCollector{}
+
+	if err := processor.processAnalyze(context.Background(), Message{ApplicationID: store.app.ID}); err != nil {
+		t.Fatalf("process analysis: %v", err)
+	}
+
+	if store.rulesWorkspaceID != store.app.WorkspaceID {
+		t.Fatalf("expected rule lookup for workspace %q, got %q", store.app.WorkspaceID, store.rulesWorkspaceID)
+	}
+	if store.rulesQueries != 1 {
+		t.Fatalf("expected one rule query per analysis, got %d", store.rulesQueries)
+	}
+	if store.incidentsCreated != 0 {
+		t.Fatalf("expected matching candidate to be suppressed, created %d incidents", store.incidentsCreated)
+	}
+	if store.desiredSnapshotsCreated != 1 || store.liveSnapshotsCreated != 1 {
+		t.Fatal("expected analysis snapshots to be persisted before candidate suppression")
+	}
+}
+
+func TestProcessAnalyzeSkipsIgnoreRulesWhenThereAreNoCandidates(t *testing.T) {
+	store := &ignoreRuleAnalysisStore{
+		app: model.Application{
+			ID:                 "application-1",
+			WorkspaceID:        "workspace-1",
+			SourceDefinitionID: "source-1",
+			ClusterID:          "cluster-1",
+			Name:               "ledger-api",
+			Namespace:          "payments",
+		},
+	}
+
+	processor := NewProcessor(store, slog.New(slog.NewTextHandler(io.Discard, nil)), ProcessorOptions{})
+	processor.fetcher = staticDesiredStateFetcher{}
+	processor.collector = unchangedLiveStateCollector{}
+
+	if err := processor.processAnalyze(context.Background(), Message{ApplicationID: store.app.ID}); err != nil {
+		t.Fatalf("process analysis: %v", err)
+	}
+
+	if store.rulesQueries != 0 {
+		t.Fatalf("expected no rule query without candidates, got %d", store.rulesQueries)
+	}
+	if store.incidentsCreated != 0 {
+		t.Fatalf("expected no incidents without drift, created %d", store.incidentsCreated)
+	}
+}
+
+type ignoreRuleAnalysisStore struct {
+	app                     model.Application
+	rules                   []model.IgnoreRule
+	rulesWorkspaceID        string
+	rulesQueries            int
+	desiredSnapshotsCreated int
+	liveSnapshotsCreated    int
+	incidentsCreated        int
+}
+
+func (*ignoreRuleAnalysisStore) MarkJobProcessing(context.Context, string) error { return nil }
+func (*ignoreRuleAnalysisStore) MarkJobCompleted(context.Context, string) error  { return nil }
+func (*ignoreRuleAnalysisStore) MarkJobFailed(context.Context, string, string) error {
+	return nil
+}
+
+func (s *ignoreRuleAnalysisStore) GetApplicationByID(context.Context, string) (model.Application, error) {
+	return s.app, nil
+}
+
+func (*ignoreRuleAnalysisStore) GetSourceDefinitionByID(context.Context, string) (model.SourceDefinition, error) {
+	return model.SourceDefinition{}, nil
+}
+
+func (*ignoreRuleAnalysisStore) GetClusterByID(context.Context, string) (model.Cluster, error) {
+	return model.Cluster{}, nil
+}
+
+func (s *ignoreRuleAnalysisStore) ListActiveIgnoreRulesByWorkspace(_ context.Context, workspaceID string) ([]model.IgnoreRule, error) {
+	s.rulesQueries++
+	s.rulesWorkspaceID = workspaceID
+	return s.rules, nil
+}
+
+func (s *ignoreRuleAnalysisStore) CreateDesiredSnapshot(context.Context, storage.CreateDesiredSnapshotParams) (model.DesiredSnapshot, error) {
+	s.desiredSnapshotsCreated++
+	return model.DesiredSnapshot{ID: "desired-1"}, nil
+}
+
+func (s *ignoreRuleAnalysisStore) CreateLiveSnapshot(context.Context, storage.CreateLiveSnapshotParams) (model.LiveSnapshot, error) {
+	s.liveSnapshotsCreated++
+	return model.LiveSnapshot{ID: "live-1"}, nil
+}
+
+func (s *ignoreRuleAnalysisStore) CreateIncident(context.Context, storage.CreateIncidentParams) (model.DriftIncident, error) {
+	s.incidentsCreated++
+	return model.DriftIncident{ID: "incident-1"}, nil
+}
+
+func (*ignoreRuleAnalysisStore) CreateDriftField(context.Context, storage.CreateDriftFieldParams) (model.DriftField, error) {
+	return model.DriftField{}, nil
+}
+
+func (*ignoreRuleAnalysisStore) CreateEvidenceRecord(context.Context, storage.CreateEvidenceRecordParams) (model.EvidenceRecord, error) {
+	return model.EvidenceRecord{}, nil
+}
+
+func (*ignoreRuleAnalysisStore) InsertGitHubEvent(context.Context, storage.UpsertGitHubEventParams) (model.GitHubEvent, error) {
+	return model.GitHubEvent{}, nil
+}
+
+type staticDesiredStateFetcher struct{}
+
+func (staticDesiredStateFetcher) FetchDesired(context.Context, model.Application, model.SourceDefinition) (sourceingest.DesiredState, error) {
+	return sourceingest.DesiredState{
+		Revision:  "revision-1",
+		Resources: []map[string]any{deploymentWithReplicas(3)},
+	}, nil
+}
+
+type staticLiveStateCollector struct{}
+
+func (staticLiveStateCollector) CollectLiveState(context.Context, model.Cluster, model.Application) (k8scollect.LiveState, error) {
+	return k8scollect.LiveState{Resources: []map[string]any{deploymentWithReplicas(2)}}, nil
+}
+
+type unchangedLiveStateCollector struct{}
+
+func (unchangedLiveStateCollector) CollectLiveState(context.Context, model.Cluster, model.Application) (k8scollect.LiveState, error) {
+	return k8scollect.LiveState{Resources: []map[string]any{deploymentWithReplicas(3)}}, nil
+}
+
+func deploymentWithReplicas(replicas int) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "ledger-api",
+			"namespace": "payments",
+		},
+		"spec": map[string]any{"replicas": replicas},
+	}
+}

--- a/internal/storage/ignore_rules.go
+++ b/internal/storage/ignore_rules.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func (r *Repository) ListActiveIgnoreRulesByWorkspace(ctx context.Context, workspaceID string) ([]model.IgnoreRule, error) {
+	const query = `
+		SELECT id, workspace_id, name, match_expression, reason, created_by, active, created_at
+		FROM ignore_rules
+		WHERE workspace_id = $1 AND active = TRUE
+		ORDER BY created_at ASC, id ASC
+	`
+
+	rows, err := r.pool.Query(ctx, query, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list active ignore rules by workspace: %w", err)
+	}
+	defer rows.Close()
+
+	rules, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (model.IgnoreRule, error) {
+		var rule model.IgnoreRule
+		err := row.Scan(
+			&rule.ID,
+			&rule.WorkspaceID,
+			&rule.Name,
+			&rule.MatchExpression,
+			&rule.Reason,
+			&rule.CreatedBy,
+			&rule.Active,
+			&rule.CreatedAt,
+		)
+		return rule, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan active ignore rules by workspace: %w", err)
+	}
+	return rules, nil
+}

--- a/migrations/0004_ignore_rules_lookup.sql
+++ b/migrations/0004_ignore_rules_lookup.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_ignore_rules_workspace_active
+    ON ignore_rules (workspace_id, created_at, id)
+    WHERE active = TRUE;


### PR DESCRIPTION
Implemented:

- Active persisted ignore rules are loaded per workspace during analysis: [ignore_rules.go](/home/anouar/Documents/Projects/StateSight/internal/storage/ignore_rules.go:12).
- The worker now suppresses incident candidates for exact `field_path` matches: [evaluator.go](/home/anouar/Documents/Projects/StateSight/internal/ignorerules/evaluator.go:9), [processor.go](/home/anouar/Documents/Projects/StateSight/internal/jobs/processor.go:181).
- Added an index for active workspace rule lookup: [0004_ignore_rules_lookup.sql](/home/anouar/Documents/Projects/StateSight/migrations/0004_ignore_rules_lookup.sql:1).
- Added evaluator and processor-path tests, including avoiding rule queries when no drift candidates exist.
- Documented the rule contract and limitation: matching is exact and workspace-wide; no wildcard, resource selector, management UI/API, or persisted suppression audit yet: [README.md](/home/anouar/Documents/Projects/StateSight/README.md:50), [DECISIONS.md](/home/anouar/Documents/Projects/StateSight/docs/DECISIONS.md:37).

Validation passed:

- `make test`
- `make lint`
- `make docs-check`
- `docker compose config --quiet`
- `git diff --check`
- Applied all migrations successfully against disposable PostgreSQL 16 and confirmed the new index exists.