### PR TITLE
Persist and surface suppressed drift findings for auditability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ StateSight is **not** a deployment controller and does not replace Argo CD or Fl
 - Go API service with versioned routes, request IDs, structured JSON responses, health/readiness, and basic metrics.
 - Go worker service that consumes Redis queue jobs and writes deterministic analysis outputs to Postgres.
 - React + TypeScript + Vite + Tailwind web app with routed pages and API-backed data loading.
-- PostgreSQL migrations for core domain entities.
+- PostgreSQL migrations for core domain entities and suppression audit records.
 - Seed workflow with realistic sample data.
 - Docker Compose local stack for Postgres, Redis, API, worker, and web.
 - Makefile commands for setup, migrate, seed, run, format, test, and docs checks.
@@ -55,7 +55,7 @@ Active `ignore_rules` rows apply within their workspace during analysis. For the
 - `spec.template.spec.containers[0].image`
 - `metadata.annotations.example.com/managed-by`
 
-Matching is case-sensitive and trims surrounding whitespace. Wildcards and regular expressions are not supported. If multiple active rules match one field path, the oldest rule is used first. A suppressed candidate does not create a drift incident; the worker records the matching rule in its structured logs.
+Matching is case-sensitive and trims surrounding whitespace. Wildcards and regular expressions are not supported. If multiple active rules match one field path, the oldest rule is used first. A suppressed candidate does not create a drift incident; instead, the worker stores a `suppressed_findings` audit record linked to the analysis snapshots and shows it in the application's Suppressed view.
 
 Rules currently have no application or resource selector: a matching field path is suppressed across the entire workspace. Use this baseline only for fields the workspace intentionally manages outside desired state.
 
@@ -150,10 +150,12 @@ make web
 - `GET /api/v1/incidents/:id/timeline`
 - `POST /api/v1/github/webhook`
 
+Application detail responses include `incidents` and `suppressions`; suppressed findings include the matching rule name and reason captured at analysis time.
+
 ## Next Suggested Implementation Steps
 
 1. Replace placeholder evidence attribution with evidence derived from real source and cluster signals.
-2. Add ignore-rule API/UI management, richer scoping, and persisted suppression audit records.
+2. Add ignore-rule API/UI management and richer application/resource-specific scoping.
 3. Expand normalization, diff coverage, and incident grouping with focused tests.
 4. Replace header-trusted identity with an authenticated workspace access flow.
 5. Add GitOps rendering/integration support and hardened Kubernetes collection.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -69,9 +69,29 @@ export type EvidenceRecord = {
   created_at: string;
 };
 
+export type SuppressedFinding = {
+  id: string;
+  application_id: string;
+  desired_snapshot_id: string;
+  live_snapshot_id: string;
+  ignore_rule_id: string;
+  ignore_rule_name: string;
+  ignore_rule_reason: string;
+  title: string;
+  category: string;
+  severity: string;
+  resource_ref: string;
+  field_path: string;
+  desired_value: string;
+  live_value: string;
+  difference_type: string;
+  suppressed_at: string;
+};
+
 export type ApplicationDetails = {
   application: Application;
   incidents: Incident[];
+  suppressions: SuppressedFinding[];
 };
 
 export type IncidentDetails = {

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,13 +1,20 @@
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 import { analyzeApplication, getApplication } from "../lib/api";
 import { Badge, recommendationTone, severityTone } from "../components/Badge";
 
-const tabs = ["Incidents", "Resources", "Timeline", "Ignore Rules"];
+const tabs = [
+  { id: "incidents", label: "Incidents" },
+  { id: "suppressions", label: "Suppressed" }
+] as const;
+
+type ApplicationTab = (typeof tabs)[number]["id"];
 
 export function ApplicationDetailPage() {
   const params = useParams<{ id: string }>();
   const id = params.id ?? "";
+  const [activeTab, setActiveTab] = useState<ApplicationTab>("incidents");
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey: ["application", id],
@@ -32,6 +39,7 @@ export function ApplicationDetailPage() {
   if (!data) {
     return <p className="text-ops-muted">Application not found.</p>;
   }
+  const suppressions = data.suppressions ?? [];
 
   return (
     <section className="space-y-6">
@@ -54,57 +62,101 @@ export function ApplicationDetailPage() {
 
       <div className="rounded-xl border border-ops-border bg-ops-panel p-4 shadow-panel">
         <div className="flex flex-wrap gap-2 border-b border-ops-border pb-3">
-          {tabs.map((tab, index) => (
+          {tabs.map((tab) => (
             <button
-              key={tab}
+              key={tab.id}
               type="button"
-              className={`rounded-md px-3 py-1.5 text-sm ${index === 0 ? "bg-[#1a2636] text-ops-text" : "text-ops-muted hover:bg-[#1a2636]"}`}
+              className={`rounded-md px-3 py-1.5 text-sm ${
+                activeTab === tab.id ? "bg-[#1a2636] text-ops-text" : "text-ops-muted hover:bg-[#1a2636]"
+              }`}
+              onClick={() => setActiveTab(tab.id)}
             >
-              {tab}
+              {tab.label}
             </button>
           ))}
         </div>
 
-        <div className="mt-4 overflow-hidden rounded-lg border border-ops-border">
-          <table className="min-w-full divide-y divide-ops-border text-sm">
-            <thead className="bg-[#111a26] text-left text-xs uppercase tracking-wide text-ops-muted">
-              <tr>
-                <th className="px-4 py-3">Incident</th>
-                <th className="px-4 py-3">Category</th>
-                <th className="px-4 py-3">Severity</th>
-                <th className="px-4 py-3">Recommendation</th>
-                <th className="px-4 py-3 text-right">Detail</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-ops-border">
-              {data.incidents.length === 0 ? (
+        {activeTab === "incidents" ? (
+          <div className="mt-4 overflow-x-auto rounded-lg border border-ops-border">
+            <table className="min-w-[720px] w-full divide-y divide-ops-border text-sm">
+              <thead className="bg-[#111a26] text-left text-xs uppercase tracking-wide text-ops-muted">
                 <tr>
-                  <td className="px-4 py-6 text-ops-muted" colSpan={5}>
-                    No incidents yet. Run an analysis to generate baseline drift findings.
-                  </td>
+                  <th className="px-4 py-3">Incident</th>
+                  <th className="px-4 py-3">Category</th>
+                  <th className="px-4 py-3">Severity</th>
+                  <th className="px-4 py-3">Recommendation</th>
+                  <th className="px-4 py-3 text-right">Detail</th>
                 </tr>
-              ) : (
-                data.incidents.map((incident) => (
-                  <tr key={incident.id} className="hover:bg-[#162132]">
-                    <td className="px-4 py-3 font-medium">{incident.title}</td>
-                    <td className="px-4 py-3 text-ops-muted">{incident.category}</td>
-                    <td className="px-4 py-3">
-                      <Badge label={incident.severity} tone={severityTone(incident.severity)} />
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge label={incident.recommended_action} tone={recommendationTone(incident.recommended_action)} />
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <Link to={`/incidents/${incident.id}`} className="font-medium text-ops-accent hover:underline">
-                        View
-                      </Link>
+              </thead>
+              <tbody className="divide-y divide-ops-border">
+                {data.incidents.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-ops-muted" colSpan={5}>
+                      No incidents recorded.
                     </td>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                ) : (
+                  data.incidents.map((incident) => (
+                    <tr key={incident.id} className="hover:bg-[#162132]">
+                      <td className="px-4 py-3 font-medium">{incident.title}</td>
+                      <td className="px-4 py-3 text-ops-muted">{incident.category}</td>
+                      <td className="px-4 py-3">
+                        <Badge label={incident.severity} tone={severityTone(incident.severity)} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge label={incident.recommended_action} tone={recommendationTone(incident.recommended_action)} />
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Link to={`/incidents/${incident.id}`} className="font-medium text-ops-accent hover:underline">
+                          View
+                        </Link>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="mt-4 overflow-x-auto rounded-lg border border-ops-border">
+            <table className="min-w-[760px] w-full divide-y divide-ops-border text-sm">
+              <thead className="bg-[#111a26] text-left text-xs uppercase tracking-wide text-ops-muted">
+                <tr>
+                  <th className="px-4 py-3">Field</th>
+                  <th className="px-4 py-3">Resource</th>
+                  <th className="px-4 py-3">Rule</th>
+                  <th className="px-4 py-3">Suppressed</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-ops-border">
+                {suppressions.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-ops-muted" colSpan={4}>
+                      No suppressed findings recorded.
+                    </td>
+                  </tr>
+                ) : (
+                  suppressions.map((suppression) => (
+                    <tr key={suppression.id} className="hover:bg-[#162132]">
+                      <td className="px-4 py-3">
+                        <p className="font-mono text-xs text-ops-text">{suppression.field_path}</p>
+                        <p className="mt-1 text-xs text-ops-muted">{suppression.title}</p>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-ops-muted">{suppression.resource_ref}</td>
+                      <td className="px-4 py-3">
+                        <p>{suppression.ignore_rule_name}</p>
+                        <p className="mt-1 text-xs text-ops-muted">{suppression.ignore_rule_reason}</p>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-ops-muted">
+                        {new Date(suppression.suppressed_at).toLocaleString()}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/docs/ARCHITECTURE-NOTES.md
+++ b/docs/ARCHITECTURE-NOTES.md
@@ -27,6 +27,7 @@ This is a high-level direction, not a fixed final architecture.
 - DriftField
 - EvidenceRecord
 - IgnoreRule
+- SuppressedFinding
 
 ## Design Direction
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -39,4 +39,11 @@ Use this file to record meaningful project decisions as the codebase grows.
   Context: The schema contains persisted ignore rules, but the worker previously ignored them. A broad or implicit expression language would make suppression difficult to reason about before rule-management and audit surfaces exist.
   Options considered: keep rules inactive until UI work, interpret expressions as glob or regular-expression patterns, implement exact field-path matching first.
   Chosen approach: load active rules for an application's workspace and suppress only candidates whose canonical field path exactly matches `match_expression`.
-  Consequences: common known-noise fields can be suppressed deterministically across a workspace; resource-specific matching, wildcard matching, management endpoints, and persisted suppression audit records remain future work.
+  Consequences: common known-noise fields can be suppressed deterministically across a workspace; resource-specific matching, wildcard matching, and management endpoints remain future work.
+
+- Date: 2026-05-25
+  Decision: Suppressed findings are persisted as audit records instead of existing only in logs.
+  Context: Ignore-rule evaluation prevents incident creation, but operators still need an inspectable record of drift that was withheld and the rule that caused it.
+  Options considered: log suppression only, model suppressed findings as ordinary incidents, store dedicated suppression audit records.
+  Chosen approach: store a `suppressed_findings` record linked to desired/live snapshots and capture matching rule name/reason at suppression time.
+  Consequences: application details can show hidden drift without conflating it with actionable incidents; future rule editing or deletion does not erase the recorded explanation.

--- a/docs/PROJECT-OVERVIEW.md
+++ b/docs/PROJECT-OVERVIEW.md
@@ -31,6 +31,6 @@ It is designed to help teams understand drift between:
 
 ## Current Stage
 
-The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, timelines, and workspace RBAC boundaries.
+The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, ignore-rule suppression auditing, timelines, and workspace RBAC boundaries.
 
 Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, managed and auditable ignore rules, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,12 +15,13 @@
 - enforce real-live-state collection by default; synthetic results are explicit demo behavior only
 - pass worker runtime configuration to source and cluster adapters
 - execute active workspace ignore rules for exact drift field-path matches
+- persist and surface audit records for suppressed findings
 - establish CI and focused tests for critical analysis boundaries
 
 ## Next: Trustworthy Analysis
 
 - replace placeholder evidence attribution with real provenance signals
-- add ignore-rule management APIs/UI, richer match scopes, and persisted suppression audit records
+- add ignore-rule management APIs/UI and richer application/resource-specific match scopes
 - improve incident grouping and semantic normalization/diff coverage
 - replace trusted request headers with a real authentication integration
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -6,7 +6,7 @@ StateSight baseline provides a minimal but extensible end-to-end path:
 
 1. API accepts analyze/webhook requests.
 2. API records job metadata in Postgres and enqueues job message in Redis.
-3. Worker consumes jobs and writes snapshots/incidents/evidence.
+3. Worker consumes jobs and writes snapshots, incidents or suppression audits, and evidence.
 4. Web app reads API data and renders overview, application, and incident pages.
 
 The current worker obtains desired state by cloning configured Git sources and obtains live state through `kubectl`. Failure to collect live state fails an analysis by default; synthetic live state is an explicit local-demo option and is not trustworthy forensic evidence.
@@ -19,7 +19,7 @@ The current worker obtains desired state by cloning configured Git sources and o
 
 ## Data and Queue
 
-- PostgreSQL: source of truth for applications, snapshots, incidents, evidence, jobs, and event metadata.
+- PostgreSQL: source of truth for applications, snapshots, incidents, suppressed findings, evidence, jobs, and event metadata.
 - Redis: lightweight queue transport for asynchronous work.
 
 ## Worker Runtime Configuration
@@ -35,7 +35,8 @@ The current worker obtains desired state by cloning configured Git sources and o
 - Each baseline `match_expression` is an exact, case-sensitive drift field path after trimming surrounding whitespace.
 - A rule applies to that field path across its workspace; resource- or application-specific selectors are not supported yet.
 - Rules are considered in creation order, with ID as a deterministic tie-breaker; the first match suppresses incident creation for that candidate.
-- Suppressed candidates are currently reported in worker logs. Persisted suppression auditing and rule-management APIs are future work.
+- A suppression writes a `suppressed_findings` audit record linked to the analysis snapshots and a snapshot of the rule name/reason, then appears in application details.
+- Rule-management APIs and UI remain future work.
 
 ## Key Internal Boundaries
 

--- a/internal/apihttp/dto.go
+++ b/internal/apihttp/dto.go
@@ -11,8 +11,9 @@ type createApplicationRequest struct {
 }
 
 type applicationDetailsResponse struct {
-	Application model.Application     `json:"application"`
-	Incidents   []model.DriftIncident `json:"incidents"`
+	Application  model.Application         `json:"application"`
+	Incidents    []model.DriftIncident     `json:"incidents"`
+	Suppressions []model.SuppressedFinding `json:"suppressions"`
 }
 
 type analyzeResponse struct {

--- a/internal/apihttp/server.go
+++ b/internal/apihttp/server.go
@@ -30,6 +30,7 @@ type Store interface {
 	CreateApplication(ctx context.Context, params storage.CreateApplicationParams) (model.Application, error)
 	GetApplicationByID(ctx context.Context, id string) (model.Application, error)
 	ListIncidentsByApplication(ctx context.Context, applicationID string) ([]model.DriftIncident, error)
+	ListSuppressedFindingsByApplication(ctx context.Context, applicationID string) ([]model.SuppressedFinding, error)
 	CreateJob(ctx context.Context, params storage.CreateJobParams) (model.Job, error)
 	MarkJobFailed(ctx context.Context, id, message string) error
 	GetIncidentDetails(ctx context.Context, id string) (model.IncidentDetails, error)
@@ -217,9 +218,17 @@ func (s *Server) handleGetApplication(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	suppressions, err := s.store.ListSuppressedFindingsByApplication(r.Context(), app.ID)
+	if err != nil {
+		s.logger.Error("list application suppressed findings failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "application_suppressions_query_failed", "failed to load application suppressions", s.responseMeta(r))
+		return
+	}
+
 	writeSuccess(w, http.StatusOK, applicationDetailsResponse{
-		Application: app,
-		Incidents:   incidents,
+		Application:  app,
+		Incidents:    incidents,
+		Suppressions: suppressions,
 	}, s.responseMeta(r))
 }
 

--- a/internal/apihttp/server_test.go
+++ b/internal/apihttp/server_test.go
@@ -2,6 +2,7 @@ package apihttp
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -31,6 +32,9 @@ func (m mockStore) GetApplicationByID(context.Context, string) (model.Applicatio
 	return model.Application{}, storage.ErrNotFound
 }
 func (m mockStore) ListIncidentsByApplication(context.Context, string) ([]model.DriftIncident, error) {
+	return nil, nil
+}
+func (m mockStore) ListSuppressedFindingsByApplication(context.Context, string) ([]model.SuppressedFinding, error) {
 	return nil, nil
 }
 func (m mockStore) CreateJob(context.Context, storage.CreateJobParams) (model.Job, error) {
@@ -65,5 +69,39 @@ func TestHealthz(t *testing.T) {
 	body, _ := io.ReadAll(rec.Body)
 	if string(body) == "" {
 		t.Fatal("expected body to be non-empty")
+	}
+}
+
+type applicationDetailsStore struct {
+	mockStore
+}
+
+func (applicationDetailsStore) GetApplicationByID(context.Context, string) (model.Application, error) {
+	return model.Application{ID: "application-1"}, nil
+}
+
+func (applicationDetailsStore) ListSuppressedFindingsByApplication(context.Context, string) ([]model.SuppressedFinding, error) {
+	return []model.SuppressedFinding{{ID: "suppressed-1", FieldPath: "spec.replicas"}}, nil
+}
+
+func TestGetApplicationIncludesSuppressedFindings(t *testing.T) {
+	s := NewServer(applicationDetailsStore{}, mockQueue{}, slog.Default(), "", false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/applications/application-1", nil)
+	rec := httptest.NewRecorder()
+
+	s.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var response struct {
+		Data applicationDetailsResponse `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Data.Suppressions) != 1 || response.Data.Suppressions[0].ID != "suppressed-1" {
+		t.Fatalf("expected suppression audit record in application response, got %#v", response.Data.Suppressions)
 	}
 }

--- a/internal/jobs/processor.go
+++ b/internal/jobs/processor.go
@@ -32,6 +32,7 @@ type Store interface {
 	CreateIncident(ctx context.Context, params storage.CreateIncidentParams) (model.DriftIncident, error)
 	CreateDriftField(ctx context.Context, params storage.CreateDriftFieldParams) (model.DriftField, error)
 	CreateEvidenceRecord(ctx context.Context, params storage.CreateEvidenceRecordParams) (model.EvidenceRecord, error)
+	CreateSuppressedFinding(ctx context.Context, params storage.CreateSuppressedFindingParams) (model.SuppressedFinding, error)
 	InsertGitHubEvent(ctx context.Context, params storage.UpsertGitHubEventParams) (model.GitHubEvent, error)
 }
 
@@ -189,6 +190,25 @@ func (p *Processor) processAnalyze(ctx context.Context, msg Message) error {
 	for _, candidate := range candidates {
 		rule, ignored := p.ignoreEvaluator.FindMatch(rules, candidate.FieldPath)
 		if ignored {
+			_, err = p.store.CreateSuppressedFinding(ctx, storage.CreateSuppressedFindingParams{
+				ApplicationID:     app.ID,
+				DesiredSnapshotID: desiredSnapshot.ID,
+				LiveSnapshotID:    liveSnapshot.ID,
+				IgnoreRuleID:      rule.ID,
+				IgnoreRuleName:    rule.Name,
+				IgnoreRuleReason:  rule.Reason,
+				Title:             candidate.Title,
+				Category:          candidate.Category,
+				Severity:          candidate.Severity,
+				ResourceRef:       candidate.ResourceRef,
+				FieldPath:         candidate.FieldPath,
+				DesiredValue:      candidate.DesiredValue,
+				LiveValue:         candidate.LiveValue,
+				DifferenceType:    candidate.DifferenceType,
+			})
+			if err != nil {
+				return fmt.Errorf("create suppressed finding: %w", err)
+			}
 			p.logger.Info(
 				"candidate ignored by rule",
 				"application_id", app.ID,

--- a/internal/jobs/processor_ignore_rules_test.go
+++ b/internal/jobs/processor_ignore_rules_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -48,6 +49,16 @@ func TestProcessAnalyzeSuppressesCandidateMatchingWorkspaceIgnoreRule(t *testing
 	if store.incidentsCreated != 0 {
 		t.Fatalf("expected matching candidate to be suppressed, created %d incidents", store.incidentsCreated)
 	}
+	if len(store.suppressedFindings) != 1 {
+		t.Fatalf("expected one suppression audit record, got %d", len(store.suppressedFindings))
+	}
+	suppressed := store.suppressedFindings[0]
+	if suppressed.IgnoreRuleID != "rule-1" || suppressed.FieldPath != "spec.replicas" {
+		t.Fatalf("unexpected suppression audit payload: %#v", suppressed)
+	}
+	if suppressed.DesiredSnapshotID != "desired-1" || suppressed.LiveSnapshotID != "live-1" {
+		t.Fatalf("expected suppression record linked to analysis snapshots, got %#v", suppressed)
+	}
 	if store.desiredSnapshotsCreated != 1 || store.liveSnapshotsCreated != 1 {
 		t.Fatal("expected analysis snapshots to be persisted before candidate suppression")
 	}
@@ -79,6 +90,40 @@ func TestProcessAnalyzeSkipsIgnoreRulesWhenThereAreNoCandidates(t *testing.T) {
 	if store.incidentsCreated != 0 {
 		t.Fatalf("expected no incidents without drift, created %d", store.incidentsCreated)
 	}
+	if len(store.suppressedFindings) != 0 {
+		t.Fatalf("expected no suppressions without drift, got %d", len(store.suppressedFindings))
+	}
+}
+
+func TestProcessAnalyzeFailsWhenSuppressionCannotBeAudited(t *testing.T) {
+	store := &ignoreRuleAnalysisStore{
+		app: model.Application{
+			ID:                 "application-1",
+			WorkspaceID:        "workspace-1",
+			SourceDefinitionID: "source-1",
+			ClusterID:          "cluster-1",
+			Name:               "ledger-api",
+			Namespace:          "payments",
+		},
+		rules: []model.IgnoreRule{{
+			ID:              "rule-1",
+			MatchExpression: "spec.replicas",
+			Active:          true,
+		}},
+		suppressionErr: errors.New("storage unavailable"),
+	}
+
+	processor := NewProcessor(store, slog.New(slog.NewTextHandler(io.Discard, nil)), ProcessorOptions{})
+	processor.fetcher = staticDesiredStateFetcher{}
+	processor.collector = staticLiveStateCollector{}
+
+	err := processor.processAnalyze(context.Background(), Message{ApplicationID: store.app.ID})
+	if err == nil {
+		t.Fatal("expected analysis to fail when suppression audit cannot be persisted")
+	}
+	if store.incidentsCreated != 0 {
+		t.Fatalf("expected failed audit not to create incident, created %d", store.incidentsCreated)
+	}
 }
 
 type ignoreRuleAnalysisStore struct {
@@ -89,6 +134,8 @@ type ignoreRuleAnalysisStore struct {
 	desiredSnapshotsCreated int
 	liveSnapshotsCreated    int
 	incidentsCreated        int
+	suppressedFindings      []storage.CreateSuppressedFindingParams
+	suppressionErr          error
 }
 
 func (*ignoreRuleAnalysisStore) MarkJobProcessing(context.Context, string) error { return nil }
@@ -136,6 +183,14 @@ func (*ignoreRuleAnalysisStore) CreateDriftField(context.Context, storage.Create
 
 func (*ignoreRuleAnalysisStore) CreateEvidenceRecord(context.Context, storage.CreateEvidenceRecordParams) (model.EvidenceRecord, error) {
 	return model.EvidenceRecord{}, nil
+}
+
+func (s *ignoreRuleAnalysisStore) CreateSuppressedFinding(_ context.Context, params storage.CreateSuppressedFindingParams) (model.SuppressedFinding, error) {
+	if s.suppressionErr != nil {
+		return model.SuppressedFinding{}, s.suppressionErr
+	}
+	s.suppressedFindings = append(s.suppressedFindings, params)
+	return model.SuppressedFinding{ID: "suppressed-1"}, nil
 }
 
 func (*ignoreRuleAnalysisStore) InsertGitHubEvent(context.Context, storage.UpsertGitHubEventParams) (model.GitHubEvent, error) {

--- a/internal/storage/suppressed_findings.go
+++ b/internal/storage/suppressed_findings.go
@@ -1,0 +1,113 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/AnouarMohamed/StateSight/pkg/model"
+)
+
+func (r *Repository) CreateSuppressedFinding(ctx context.Context, params CreateSuppressedFindingParams) (model.SuppressedFinding, error) {
+	const query = `
+		INSERT INTO suppressed_findings (
+			id, application_id, desired_snapshot_id, live_snapshot_id, ignore_rule_id,
+			ignore_rule_name, ignore_rule_reason, title, category, severity,
+			resource_ref, field_path, desired_value, live_value, difference_type
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		RETURNING id, application_id, desired_snapshot_id, live_snapshot_id,
+			COALESCE(ignore_rule_id::text, ''), ignore_rule_name, ignore_rule_reason,
+			title, category, severity, resource_ref, field_path, desired_value,
+			live_value, difference_type, suppressed_at
+	`
+
+	var record model.SuppressedFinding
+	err := r.pool.QueryRow(
+		ctx,
+		query,
+		uuid.NewString(),
+		params.ApplicationID,
+		params.DesiredSnapshotID,
+		params.LiveSnapshotID,
+		params.IgnoreRuleID,
+		params.IgnoreRuleName,
+		params.IgnoreRuleReason,
+		params.Title,
+		params.Category,
+		params.Severity,
+		params.ResourceRef,
+		params.FieldPath,
+		params.DesiredValue,
+		params.LiveValue,
+		params.DifferenceType,
+	).Scan(
+		&record.ID,
+		&record.ApplicationID,
+		&record.DesiredSnapshotID,
+		&record.LiveSnapshotID,
+		&record.IgnoreRuleID,
+		&record.IgnoreRuleName,
+		&record.IgnoreRuleReason,
+		&record.Title,
+		&record.Category,
+		&record.Severity,
+		&record.ResourceRef,
+		&record.FieldPath,
+		&record.DesiredValue,
+		&record.LiveValue,
+		&record.DifferenceType,
+		&record.SuppressedAt,
+	)
+	if err != nil {
+		return model.SuppressedFinding{}, fmt.Errorf("create suppressed finding: %w", err)
+	}
+	return record, nil
+}
+
+func (r *Repository) ListSuppressedFindingsByApplication(ctx context.Context, applicationID string) ([]model.SuppressedFinding, error) {
+	const query = `
+		SELECT id, application_id, desired_snapshot_id, live_snapshot_id,
+			COALESCE(ignore_rule_id::text, ''), ignore_rule_name, ignore_rule_reason,
+			title, category, severity, resource_ref, field_path, desired_value,
+			live_value, difference_type, suppressed_at
+		FROM suppressed_findings
+		WHERE application_id = $1
+		ORDER BY suppressed_at DESC, id DESC
+	`
+
+	rows, err := r.pool.Query(ctx, query, applicationID)
+	if err != nil {
+		return nil, fmt.Errorf("query suppressed findings by application: %w", err)
+	}
+	defer rows.Close()
+
+	records, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (model.SuppressedFinding, error) {
+		var record model.SuppressedFinding
+		err := row.Scan(
+			&record.ID,
+			&record.ApplicationID,
+			&record.DesiredSnapshotID,
+			&record.LiveSnapshotID,
+			&record.IgnoreRuleID,
+			&record.IgnoreRuleName,
+			&record.IgnoreRuleReason,
+			&record.Title,
+			&record.Category,
+			&record.Severity,
+			&record.ResourceRef,
+			&record.FieldPath,
+			&record.DesiredValue,
+			&record.LiveValue,
+			&record.DifferenceType,
+			&record.SuppressedAt,
+		)
+		return record, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect suppressed findings by application: %w", err)
+	}
+	return records, nil
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -55,6 +55,23 @@ type CreateEvidenceRecordParams struct {
 	Metadata   string
 }
 
+type CreateSuppressedFindingParams struct {
+	ApplicationID     string
+	DesiredSnapshotID string
+	LiveSnapshotID    string
+	IgnoreRuleID      string
+	IgnoreRuleName    string
+	IgnoreRuleReason  string
+	Title             string
+	Category          string
+	Severity          string
+	ResourceRef       string
+	FieldPath         string
+	DesiredValue      string
+	LiveValue         string
+	DifferenceType    string
+}
+
 type UpsertGitHubEventParams struct {
 	EventType  string
 	DeliveryID string

--- a/migrations/0005_suppressed_findings.sql
+++ b/migrations/0005_suppressed_findings.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS suppressed_findings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    desired_snapshot_id UUID NOT NULL REFERENCES desired_snapshots(id) ON DELETE CASCADE,
+    live_snapshot_id UUID NOT NULL REFERENCES live_snapshots(id) ON DELETE CASCADE,
+    ignore_rule_id UUID REFERENCES ignore_rules(id) ON DELETE SET NULL,
+    ignore_rule_name TEXT NOT NULL,
+    ignore_rule_reason TEXT NOT NULL,
+    title TEXT NOT NULL,
+    category TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    resource_ref TEXT NOT NULL,
+    field_path TEXT NOT NULL,
+    desired_value TEXT NOT NULL,
+    live_value TEXT NOT NULL,
+    difference_type TEXT NOT NULL,
+    suppressed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_suppressed_findings_application
+    ON suppressed_findings (application_id, suppressed_at DESC);

--- a/pkg/model/suppressed_finding.go
+++ b/pkg/model/suppressed_finding.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+// SuppressedFinding is a drift candidate withheld from incidents by an ignore rule.
+type SuppressedFinding struct {
+	ID                string    `json:"id"`
+	ApplicationID     string    `json:"application_id"`
+	DesiredSnapshotID string    `json:"desired_snapshot_id"`
+	LiveSnapshotID    string    `json:"live_snapshot_id"`
+	IgnoreRuleID      string    `json:"ignore_rule_id"`
+	IgnoreRuleName    string    `json:"ignore_rule_name"`
+	IgnoreRuleReason  string    `json:"ignore_rule_reason"`
+	Title             string    `json:"title"`
+	Category          string    `json:"category"`
+	Severity          string    `json:"severity"`
+	ResourceRef       string    `json:"resource_ref"`
+	FieldPath         string    `json:"field_path"`
+	DesiredValue      string    `json:"desired_value"`
+	LiveValue         string    `json:"live_value"`
+	DifferenceType    string    `json:"difference_type"`
+	SuppressedAt      time.Time `json:"suppressed_at"`
+}


### PR DESCRIPTION
## Summary

- persist drift findings suppressed by ignore rules as audit records
- expose suppressed findings in application detail responses
- add a functional Suppressed view in the application UI
- document the suppression audit contract and retained rule metadata behavior

## Rationale

Ignored drift was previously prevented from creating incidents but was only visible through worker logs. This made suppression difficult to inspect after analysis and fragile when ignore rules changed or were removed.

This change records each suppressed finding with its associated snapshots and a captured copy of the matching rule name and reason. Audit history therefore remains understandable even if the original rule is later deleted.

## Implementation

- add the `suppressed_findings` table and application query index
- create storage methods for recording and listing suppressed findings
- require the worker to persist a suppression audit record before withholding an incident
- return suppression records from the application details endpoint
- add `Incidents` and `Suppressed` tabs to the application detail view
- document the new behavior in project, architecture, roadmap, and decision records

## Verification

- `make test`
- `make lint`
- `make docs-check`
- `docker compose config --quiet`
- `cd apps/web && npm run build`
- `git diff --check origin/main...HEAD`
- applied migrations through `0005` against disposable PostgreSQL
- verified application details API returns suppressed findings
- verified audit metadata remains available after deleting the referenced ignore rule

## Notes

- this change surfaces suppression history but does not add ignore-rule management endpoints or UI
- `npm ci` reported existing dependency vulnerabilities; no dependency remediation is included in this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added suppression auditing and visualization: suppressed drift candidates are now persistently recorded and displayed in a dedicated "Suppressions" tab on the application details page, showing the applied ignore rule name, suppression reason, and suppression timestamp.

* **Documentation**
  * Updated architecture and project documentation to reflect suppression auditing as part of the baseline analyze workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnouarMohamed/StateSight/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->