### PR TITLE
Add scoped ignore-rule management and reliable local UI API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ StateSight is **not** a deployment controller and does not replace Argo CD or Fl
 - Go API service with versioned routes, request IDs, structured JSON responses, health/readiness, and basic metrics.
 - Go worker service that consumes Redis queue jobs and writes deterministic analysis outputs to Postgres.
 - React + TypeScript + Vite + Tailwind web app with routed pages and API-backed data loading.
-- PostgreSQL migrations for core domain entities and suppression audit records.
+- PostgreSQL migrations for core domain entities, suppression audit records, and scoped ignore rules.
 - Seed workflow with realistic sample data.
 - Docker Compose local stack for Postgres, Redis, API, worker, and web.
 - Makefile commands for setup, migrate, seed, run, format, test, and docs checks.
@@ -20,7 +20,7 @@ StateSight is **not** a deployment controller and does not replace Argo CD or Fl
 
 - Semantic diffing currently covers resource presence, replica counts, first-container images, and annotations; it is not a complete Kubernetes diff engine.
 - Live-state collection uses `kubectl` for a limited resource set rather than a Kubernetes client integration.
-- Evidence attribution is placeholder data; ignore rules currently support exact field-path suppression only.
+- Evidence attribution is placeholder data; ignore rules currently support exact field-path and optional exact-resource suppression only.
 - GitHub webhook endpoint is baseline-only (not full GitHub App install/auth flow).
 - Git desired-state ingestion reads plain YAML/JSON manifests; Helm, Kustomize, Argo CD, and Flux integrations are not implemented.
 - No auto-remediation.
@@ -47,19 +47,19 @@ The worker honors:
 
 When `kubectl` cannot collect live resources, analysis fails by default. Set `ALLOW_SYNTHETIC_LIVE_STATE=true` only for local pipeline demonstrations; resulting incidents do not represent observations from a cluster.
 
-## Ignore Rule Baseline
+## Ignore Rules
 
-Active `ignore_rules` rows apply within their workspace during analysis. For the current baseline, `match_expression` is one exact drift field path, such as:
+An ignore rule's `match_expression` is one exact drift field path, such as:
 
 - `spec.replicas`
 - `spec.template.spec.containers[0].image`
 - `metadata.annotations.example.com/managed-by`
 
-Matching is case-sensitive and trims surrounding whitespace. Wildcards and regular expressions are not supported. If multiple active rules match one field path, the oldest rule is used first. A suppressed candidate does not create a drift incident; instead, the worker stores a `suppressed_findings` audit record linked to the analysis snapshots and shows it in the application's Suppressed view.
+Matching is case-sensitive and trims surrounding whitespace. Wildcards and regular expressions are not supported. Rules created through the application API or UI are scoped to that application and can optionally specify an exact `resource_ref`. Active resource-specific application rules are evaluated before application-wide rules, which are evaluated before inherited workspace rules. Within the same scope, the oldest matching rule is used first.
 
-Rules currently have no application or resource selector: a matching field path is suppressed across the entire workspace. Use this baseline only for fields the workspace intentionally manages outside desired state.
+Existing rows with no `application_id` remain inherited workspace rules for compatibility. They are displayed on application details as read-only because changing one affects every application in that workspace.
 
-Rule management API and UI surfaces are not implemented yet; persisted rules must currently be administered through the database.
+A suppressed candidate does not create a drift incident. The worker stores a `suppressed_findings` audit record linked to the analysis snapshots, including the matching rule name and reason captured at analysis time. Application details expose the audit history under `Suppressed` and rule management under `Ignore Rules`. Managed application rules can currently be created, enabled, and disabled; editing, deletion, and workspace-rule administration are not implemented.
 
 ## Architecture Overview
 
@@ -146,16 +146,18 @@ make web
 - `POST /api/v1/applications`
 - `GET /api/v1/applications/:id`
 - `POST /api/v1/applications/:id/analyze`
+- `POST /api/v1/applications/:id/ignore-rules`
+- `PATCH /api/v1/applications/:id/ignore-rules/:ruleID`
 - `GET /api/v1/incidents/:id`
 - `GET /api/v1/incidents/:id/timeline`
 - `POST /api/v1/github/webhook`
 
-Application detail responses include `incidents` and `suppressions`; suppressed findings include the matching rule name and reason captured at analysis time.
+Application detail responses include `incidents`, `suppressions`, and applicable `ignore_rules`; suppressed findings include the matching rule name and reason captured at analysis time.
 
 ## Next Suggested Implementation Steps
 
 1. Replace placeholder evidence attribution with evidence derived from real source and cluster signals.
-2. Add ignore-rule API/UI management and richer application/resource-specific scoping.
+2. Extend ignore-rule administration with editing, deletion, and deliberate workspace-wide rule management.
 3. Expand normalization, diff coverage, and incident grouping with focused tests.
 4. Replace header-trusted identity with an authenticated workspace access flow.
 5. Add GitOps rendering/integration support and hardened Kubernetes collection.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ cp .env.example .env
 cp apps/web/.env.example apps/web/.env
 ```
 
+The local Vite server uses its `/api` proxy by default. Keep `VITE_API_BASE_URL` empty in local development; Docker Compose supplies the internal API proxy target for the web container.
+
 ### 3) Start Infrastructure + Services
 
 ```bash

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=http://localhost:8080
+VITE_API_BASE_URL=
 VITE_USER_ID=cccccccc-cccc-cccc-cccc-cccccccccccc
 VITE_WORKSPACE_ID=11111111-1111-1111-1111-111111111111
 VITE_USER_EMAIL=demo.admin@statesight.local

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -88,10 +88,31 @@ export type SuppressedFinding = {
   suppressed_at: string;
 };
 
+export type IgnoreRule = {
+  id: string;
+  workspace_id: string;
+  application_id: string;
+  resource_ref: string;
+  name: string;
+  match_expression: string;
+  reason: string;
+  created_by: string;
+  active: boolean;
+  created_at: string;
+};
+
+export type CreateIgnoreRuleInput = {
+  name: string;
+  match_expression: string;
+  resource_ref: string;
+  reason: string;
+};
+
 export type ApplicationDetails = {
   application: Application;
   incidents: Incident[];
   suppressions: SuppressedFinding[];
+  ignore_rules: IgnoreRule[];
 };
 
 export type IncidentDetails = {
@@ -151,6 +172,20 @@ export function getApplication(id: string) {
 export function analyzeApplication(id: string) {
   return request<{ job_id: string; status: string }>(`/api/v1/applications/${id}/analyze`, {
     method: "POST"
+  });
+}
+
+export function createIgnoreRule(applicationId: string, input: CreateIgnoreRuleInput) {
+  return request<IgnoreRule>(`/api/v1/applications/${applicationId}/ignore-rules`, {
+    method: "POST",
+    body: JSON.stringify(input)
+  });
+}
+
+export function setIgnoreRuleActive(applicationId: string, ruleId: string, active: boolean) {
+  return request<IgnoreRule>(`/api/v1/applications/${applicationId}/ignore-rules/${ruleId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ active })
   });
 }
 

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,20 +1,32 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
-import { analyzeApplication, getApplication } from "../lib/api";
+import { analyzeApplication, createIgnoreRule, getApplication, setIgnoreRuleActive, type CreateIgnoreRuleInput } from "../lib/api";
 import { Badge, recommendationTone, severityTone } from "../components/Badge";
 
 const tabs = [
   { id: "incidents", label: "Incidents" },
-  { id: "suppressions", label: "Suppressed" }
+  { id: "suppressions", label: "Suppressed" },
+  { id: "ignore-rules", label: "Ignore Rules" }
 ] as const;
 
 type ApplicationTab = (typeof tabs)[number]["id"];
+
+const emptyRuleDraft: CreateIgnoreRuleInput = {
+  name: "",
+  match_expression: "",
+  resource_ref: "",
+  reason: ""
+};
+
+const inputClass =
+  "mt-1 block w-full rounded-md border border-ops-border bg-[#0e1621] px-3 py-2 text-sm text-ops-text outline-none focus:border-ops-accent";
 
 export function ApplicationDetailPage() {
   const params = useParams<{ id: string }>();
   const id = params.id ?? "";
   const [activeTab, setActiveTab] = useState<ApplicationTab>("incidents");
+  const [ruleDraft, setRuleDraft] = useState<CreateIgnoreRuleInput>(emptyRuleDraft);
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey: ["application", id],
@@ -30,6 +42,21 @@ export function ApplicationDetailPage() {
     }
   });
 
+  const createRuleMutation = useMutation({
+    mutationFn: (input: CreateIgnoreRuleInput) => createIgnoreRule(id, input),
+    onSuccess: async () => {
+      setRuleDraft(emptyRuleDraft);
+      await queryClient.invalidateQueries({ queryKey: ["application", id] });
+    }
+  });
+
+  const ruleStatusMutation = useMutation({
+    mutationFn: ({ ruleId, active }: { ruleId: string; active: boolean }) => setIgnoreRuleActive(id, ruleId, active),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["application", id] });
+    }
+  });
+
   if (isLoading) {
     return <p className="text-ops-muted">Loading application details...</p>;
   }
@@ -40,6 +67,7 @@ export function ApplicationDetailPage() {
     return <p className="text-ops-muted">Application not found.</p>;
   }
   const suppressions = data.suppressions ?? [];
+  const ignoreRules = data.ignore_rules ?? [];
 
   return (
     <section className="space-y-6">
@@ -117,7 +145,7 @@ export function ApplicationDetailPage() {
               </tbody>
             </table>
           </div>
-        ) : (
+        ) : activeTab === "suppressions" ? (
           <div className="mt-4 overflow-x-auto rounded-lg border border-ops-border">
             <table className="min-w-[760px] w-full divide-y divide-ops-border text-sm">
               <thead className="bg-[#111a26] text-left text-xs uppercase tracking-wide text-ops-muted">
@@ -155,6 +183,135 @@ export function ApplicationDetailPage() {
                 )}
               </tbody>
             </table>
+          </div>
+        ) : (
+          <div className="mt-4">
+            <form
+              className="grid gap-4 border-b border-ops-border pb-5 md:grid-cols-2"
+              onSubmit={(event) => {
+                event.preventDefault();
+                createRuleMutation.mutate(ruleDraft);
+              }}
+            >
+              <div>
+                <label className="text-sm text-ops-muted" htmlFor="rule-name">
+                  Name
+                </label>
+                <input
+                  id="rule-name"
+                  className={inputClass}
+                  required
+                  value={ruleDraft.name}
+                  onChange={(event) => setRuleDraft((draft) => ({ ...draft, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm text-ops-muted" htmlFor="rule-field">
+                  Field path
+                </label>
+                <input
+                  id="rule-field"
+                  className={inputClass}
+                  required
+                  placeholder="spec.replicas"
+                  value={ruleDraft.match_expression}
+                  onChange={(event) => setRuleDraft((draft) => ({ ...draft, match_expression: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm text-ops-muted" htmlFor="rule-resource">
+                  Resource reference
+                </label>
+                <input
+                  id="rule-resource"
+                  className={inputClass}
+                  placeholder="apps/v1/Deployment:payments/ledger-api"
+                  value={ruleDraft.resource_ref}
+                  onChange={(event) => setRuleDraft((draft) => ({ ...draft, resource_ref: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm text-ops-muted" htmlFor="rule-reason">
+                  Reason
+                </label>
+                <input
+                  id="rule-reason"
+                  className={inputClass}
+                  required
+                  value={ruleDraft.reason}
+                  onChange={(event) => setRuleDraft((draft) => ({ ...draft, reason: event.target.value }))}
+                />
+              </div>
+              <div className="flex items-center gap-3 md:col-span-2">
+                <button
+                  type="submit"
+                  className="rounded-md bg-ops-accent px-4 py-2 text-sm font-semibold text-[#09111a] hover:opacity-90 disabled:opacity-60"
+                  disabled={createRuleMutation.isPending}
+                >
+                  {createRuleMutation.isPending ? "Creating..." : "Create Rule"}
+                </button>
+                {createRuleMutation.error ? (
+                  <p className="text-sm text-ops-bad">{(createRuleMutation.error as Error).message}</p>
+                ) : null}
+              </div>
+            </form>
+
+            <div className="mt-5 overflow-x-auto rounded-lg border border-ops-border">
+              <table className="min-w-[800px] w-full divide-y divide-ops-border text-sm">
+                <thead className="bg-[#111a26] text-left text-xs uppercase tracking-wide text-ops-muted">
+                  <tr>
+                    <th className="px-4 py-3">Rule</th>
+                    <th className="px-4 py-3">Match</th>
+                    <th className="px-4 py-3">Scope</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3 text-right">Action</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-ops-border">
+                  {ignoreRules.length === 0 ? (
+                    <tr>
+                      <td className="px-4 py-6 text-ops-muted" colSpan={5}>
+                        No ignore rules configured.
+                      </td>
+                    </tr>
+                  ) : (
+                    ignoreRules.map((rule) => (
+                      <tr key={rule.id} className="hover:bg-[#162132]">
+                        <td className="px-4 py-3">
+                          <p className="font-medium">{rule.name}</p>
+                          <p className="mt-1 text-xs text-ops-muted">{rule.reason}</p>
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs text-ops-text">{rule.match_expression}</td>
+                        <td className="px-4 py-3">
+                          <p>{rule.application_id ? "Application" : "Workspace (inherited)"}</p>
+                          {rule.resource_ref ? <p className="mt-1 font-mono text-xs text-ops-muted">{rule.resource_ref}</p> : null}
+                        </td>
+                        <td className="px-4 py-3">
+                          <Badge label={rule.active ? "Active" : "Inactive"} tone={rule.active ? "good" : "neutral"} />
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          {rule.application_id === data.application.id ? (
+                            <button
+                              type="button"
+                              className="font-medium text-ops-accent hover:underline disabled:text-ops-muted"
+                              disabled={ruleStatusMutation.isPending}
+                              onClick={() => ruleStatusMutation.mutate({ ruleId: rule.id, active: !rule.active })}
+                            >
+                              {rule.active ? "Disable" : "Enable"}
+                            </button>
+                          ) : (
+                            <span className="text-ops-muted">Read only</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {ruleStatusMutation.error ? (
+              <p className="mt-3 text-sm text-ops-bad">{(ruleStatusMutation.error as Error).message}</p>
+            ) : null}
           </div>
         )}
       </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const devAPIProxyTarget = process.env.DEV_API_PROXY_TARGET ?? "http://localhost:8080";
+
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -8,15 +10,15 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://localhost:8080",
+        target: devAPIProxyTarget,
         changeOrigin: true
       },
       "/healthz": {
-        target: "http://localhost:8080",
+        target: devAPIProxyTarget,
         changeOrigin: true
       },
       "/readyz": {
-        target: "http://localhost:8080",
+        target: devAPIProxyTarget,
         changeOrigin: true
       }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     container_name: statesight-web
     restart: unless-stopped
     environment:
-      VITE_API_BASE_URL: http://localhost:8080
+      DEV_API_PROXY_TARGET: http://api:8080
     depends_on:
       api:
         condition: service_started

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -39,7 +39,7 @@ Use this file to record meaningful project decisions as the codebase grows.
   Context: The schema contains persisted ignore rules, but the worker previously ignored them. A broad or implicit expression language would make suppression difficult to reason about before rule-management and audit surfaces exist.
   Options considered: keep rules inactive until UI work, interpret expressions as glob or regular-expression patterns, implement exact field-path matching first.
   Chosen approach: load active rules for an application's workspace and suppress only candidates whose canonical field path exactly matches `match_expression`.
-  Consequences: common known-noise fields can be suppressed deterministically across a workspace; resource-specific matching, wildcard matching, and management endpoints remain future work.
+  Consequences: common known-noise fields can be suppressed deterministically across a workspace; wildcard matching remains out of scope, while later management work can narrow rule reach.
 
 - Date: 2026-05-25
   Decision: Suppressed findings are persisted as audit records instead of existing only in logs.
@@ -47,3 +47,10 @@ Use this file to record meaningful project decisions as the codebase grows.
   Options considered: log suppression only, model suppressed findings as ordinary incidents, store dedicated suppression audit records.
   Chosen approach: store a `suppressed_findings` record linked to desired/live snapshots and capture matching rule name/reason at suppression time.
   Consequences: application details can show hidden drift without conflating it with actionable incidents; future rule editing or deletion does not erase the recorded explanation.
+
+- Date: 2026-05-25
+  Decision: Newly managed ignore rules are application-scoped with optional exact resource restriction.
+  Context: Workspace-wide field suppression is too broad for routine operator management, but existing rules must keep their behavior after an upgrade.
+  Options considered: keep workspace-only rules, require every rule to specify one resource, support application scope with optional exact resource matching while retaining legacy rows.
+  Chosen approach: API/UI-created rules always reference one application and may store one exact `resource_ref`; null-application rows remain inherited workspace rules and appear read-only in application details.
+  Consequences: operators can suppress expected drift with narrower blast radius, resource-specific rules take precedence over broader effective rules, and editing or administering inherited workspace rules remains future work.

--- a/docs/PROJECT-OVERVIEW.md
+++ b/docs/PROJECT-OVERVIEW.md
@@ -31,6 +31,6 @@ It is designed to help teams understand drift between:
 
 ## Current Stage
 
-The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, ignore-rule suppression auditing, timelines, and workspace RBAC boundaries.
+The baseline analyze flow exists: API, Redis-backed worker, Postgres persistence, React UI, Git manifest ingestion, `kubectl` live-state collection, first semantic diffs, scoped ignore-rule management and suppression auditing, timelines, and workspace RBAC boundaries.
 
-Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, managed and auditable ignore rules, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.
+Current work is to make analysis trustworthy beyond the baseline: real evidence attribution, deeper rule administration, broader semantic coverage, stronger authentication, and test coverage around the processing pipeline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,12 +16,13 @@
 - pass worker runtime configuration to source and cluster adapters
 - execute active workspace ignore rules for exact drift field-path matches
 - persist and surface audit records for suppressed findings
+- manage application-scoped ignore rules with optional exact resource matching
 - establish CI and focused tests for critical analysis boundaries
 
 ## Next: Trustworthy Analysis
 
 - replace placeholder evidence attribution with real provenance signals
-- add ignore-rule management APIs/UI and richer application/resource-specific match scopes
+- extend ignore-rule administration with edit/delete flows and deliberate workspace-wide controls
 - improve incident grouping and semantic normalization/diff coverage
 - replace trusted request headers with a real authentication integration
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -19,7 +19,7 @@ The current worker obtains desired state by cloning configured Git sources and o
 
 ## Data and Queue
 
-- PostgreSQL: source of truth for applications, snapshots, incidents, suppressed findings, evidence, jobs, and event metadata.
+- PostgreSQL: source of truth for applications, snapshots, incidents, suppressed findings, scoped ignore rules, evidence, jobs, and event metadata.
 - Redis: lightweight queue transport for asynchronous work.
 
 ## Worker Runtime Configuration
@@ -31,12 +31,12 @@ The current worker obtains desired state by cloning configured Git sources and o
 
 ## Ignore-Rule Evaluation
 
-- The worker loads active rules for the application's workspace only when an analysis produces drift candidates.
+- The worker loads active rules applicable to the analyzed application only when analysis produces drift candidates.
 - Each baseline `match_expression` is an exact, case-sensitive drift field path after trimming surrounding whitespace.
-- A rule applies to that field path across its workspace; resource- or application-specific selectors are not supported yet.
-- Rules are considered in creation order, with ID as a deterministic tie-breaker; the first match suppresses incident creation for that candidate.
+- Application-managed rules carry an `application_id` and may additionally specify an exact `resource_ref`; legacy rules without an application remain inherited workspace rules.
+- Resource-scoped application rules are considered before application-wide rules, then inherited workspace rules. Creation time and ID provide deterministic ordering inside a scope.
 - A suppression writes a `suppressed_findings` audit record linked to the analysis snapshots and a snapshot of the rule name/reason, then appears in application details.
-- Rule-management APIs and UI remain future work.
+- Application details display applicable rules and allow creation or activation changes for application-owned rules; inherited workspace rules are read-only through this surface.
 
 ## Key Internal Boundaries
 

--- a/internal/apihttp/dto.go
+++ b/internal/apihttp/dto.go
@@ -10,10 +10,22 @@ type createApplicationRequest struct {
 	Namespace          string `json:"namespace"`
 }
 
+type createIgnoreRuleRequest struct {
+	Name            string `json:"name"`
+	MatchExpression string `json:"match_expression"`
+	ResourceRef     string `json:"resource_ref"`
+	Reason          string `json:"reason"`
+}
+
+type updateIgnoreRuleRequest struct {
+	Active *bool `json:"active"`
+}
+
 type applicationDetailsResponse struct {
 	Application  model.Application         `json:"application"`
 	Incidents    []model.DriftIncident     `json:"incidents"`
 	Suppressions []model.SuppressedFinding `json:"suppressions"`
+	IgnoreRules  []model.IgnoreRule        `json:"ignore_rules"`
 }
 
 type analyzeResponse struct {

--- a/internal/apihttp/server.go
+++ b/internal/apihttp/server.go
@@ -31,6 +31,9 @@ type Store interface {
 	GetApplicationByID(ctx context.Context, id string) (model.Application, error)
 	ListIncidentsByApplication(ctx context.Context, applicationID string) ([]model.DriftIncident, error)
 	ListSuppressedFindingsByApplication(ctx context.Context, applicationID string) ([]model.SuppressedFinding, error)
+	ListIgnoreRulesForApplication(ctx context.Context, workspaceID, applicationID string) ([]model.IgnoreRule, error)
+	CreateIgnoreRule(ctx context.Context, params storage.CreateIgnoreRuleParams) (model.IgnoreRule, error)
+	SetIgnoreRuleActiveForApplication(ctx context.Context, id, applicationID string, active bool) (model.IgnoreRule, error)
 	CreateJob(ctx context.Context, params storage.CreateJobParams) (model.Job, error)
 	MarkJobFailed(ctx context.Context, id, message string) error
 	GetIncidentDetails(ctx context.Context, id string) (model.IncidentDetails, error)
@@ -80,6 +83,8 @@ func (s *Server) Router() http.Handler {
 		v1.Post("/applications", s.handleCreateApplication)
 		v1.Get("/applications/{id}", s.handleGetApplication)
 		v1.Post("/applications/{id}/analyze", s.handleAnalyzeApplication)
+		v1.Post("/applications/{id}/ignore-rules", s.handleCreateIgnoreRule)
+		v1.Patch("/applications/{id}/ignore-rules/{ruleID}", s.handleSetIgnoreRuleActive)
 		v1.Get("/incidents/{id}", s.handleGetIncident)
 		v1.Get("/incidents/{id}/timeline", s.handleGetIncidentTimeline)
 		v1.Post("/github/webhook", s.handleGitHubWebhook)
@@ -225,11 +230,112 @@ func (s *Server) handleGetApplication(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ignoreRules, err := s.store.ListIgnoreRulesForApplication(r.Context(), app.WorkspaceID, app.ID)
+	if err != nil {
+		s.logger.Error("list application ignore rules failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "application_ignore_rules_query_failed", "failed to load application ignore rules", s.responseMeta(r))
+		return
+	}
+
 	writeSuccess(w, http.StatusOK, applicationDetailsResponse{
 		Application:  app,
 		Incidents:    incidents,
 		Suppressions: suppressions,
+		IgnoreRules:  ignoreRules,
 	}, s.responseMeta(r))
+}
+
+func (s *Server) handleCreateIgnoreRule(w http.ResponseWriter, r *http.Request) {
+	app, err := s.store.GetApplicationByID(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		if err == storage.ErrNotFound {
+			writeError(w, http.StatusNotFound, "application_not_found", "application was not found", s.responseMeta(r))
+			return
+		}
+		s.logger.Error("lookup application for ignore rule failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "application_query_failed", "failed to load application", s.responseMeta(r))
+		return
+	}
+	if !s.authorizeWorkspace(w, r, app.WorkspaceID, auth.RoleEditor) {
+		return
+	}
+
+	var req createIgnoreRuleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "request body must be valid JSON", s.responseMeta(r))
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.MatchExpression = strings.TrimSpace(req.MatchExpression)
+	req.ResourceRef = strings.TrimSpace(req.ResourceRef)
+	req.Reason = strings.TrimSpace(req.Reason)
+	if req.Name == "" || req.MatchExpression == "" || req.Reason == "" {
+		writeError(w, http.StatusBadRequest, "missing_fields", "name, match_expression, and reason are required", s.responseMeta(r))
+		return
+	}
+
+	createdBy := "api"
+	if s.authRequired {
+		principal, _ := auth.PrincipalFromRequest(r)
+		createdBy = principal.UserID
+	}
+	rule, err := s.store.CreateIgnoreRule(r.Context(), storage.CreateIgnoreRuleParams{
+		WorkspaceID:     app.WorkspaceID,
+		ApplicationID:   app.ID,
+		ResourceRef:     req.ResourceRef,
+		Name:            req.Name,
+		MatchExpression: req.MatchExpression,
+		Reason:          req.Reason,
+		CreatedBy:       createdBy,
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrConflict) {
+			writeError(w, http.StatusConflict, "ignore_rule_name_conflict", "an ignore rule with this name already exists for this application", s.responseMeta(r))
+			return
+		}
+		s.logger.Error("create application ignore rule failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "ignore_rule_create_failed", "failed to create ignore rule", s.responseMeta(r))
+		return
+	}
+	writeSuccess(w, http.StatusCreated, rule, s.responseMeta(r))
+}
+
+func (s *Server) handleSetIgnoreRuleActive(w http.ResponseWriter, r *http.Request) {
+	app, err := s.store.GetApplicationByID(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		if err == storage.ErrNotFound {
+			writeError(w, http.StatusNotFound, "application_not_found", "application was not found", s.responseMeta(r))
+			return
+		}
+		s.logger.Error("lookup application for ignore rule update failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "application_query_failed", "failed to load application", s.responseMeta(r))
+		return
+	}
+	if !s.authorizeWorkspace(w, r, app.WorkspaceID, auth.RoleEditor) {
+		return
+	}
+
+	var req updateIgnoreRuleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "request body must be valid JSON", s.responseMeta(r))
+		return
+	}
+	if req.Active == nil {
+		writeError(w, http.StatusBadRequest, "missing_fields", "active is required", s.responseMeta(r))
+		return
+	}
+
+	rule, err := s.store.SetIgnoreRuleActiveForApplication(r.Context(), chi.URLParam(r, "ruleID"), app.ID, *req.Active)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "ignore_rule_not_found", "application-owned ignore rule was not found", s.responseMeta(r))
+			return
+		}
+		s.logger.Error("update application ignore rule failed", "error", err.Error(), "request_id", requestIDFromContext(r.Context()))
+		writeError(w, http.StatusInternalServerError, "ignore_rule_update_failed", "failed to update ignore rule", s.responseMeta(r))
+		return
+	}
+	writeSuccess(w, http.StatusOK, rule, s.responseMeta(r))
 }
 
 func (s *Server) handleAnalyzeApplication(w http.ResponseWriter, r *http.Request) {

--- a/internal/apihttp/server_test.go
+++ b/internal/apihttp/server_test.go
@@ -1,6 +1,7 @@
 package apihttp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -36,6 +37,15 @@ func (m mockStore) ListIncidentsByApplication(context.Context, string) ([]model.
 }
 func (m mockStore) ListSuppressedFindingsByApplication(context.Context, string) ([]model.SuppressedFinding, error) {
 	return nil, nil
+}
+func (m mockStore) ListIgnoreRulesForApplication(context.Context, string, string) ([]model.IgnoreRule, error) {
+	return nil, nil
+}
+func (m mockStore) CreateIgnoreRule(context.Context, storage.CreateIgnoreRuleParams) (model.IgnoreRule, error) {
+	return model.IgnoreRule{}, nil
+}
+func (m mockStore) SetIgnoreRuleActiveForApplication(context.Context, string, string, bool) (model.IgnoreRule, error) {
+	return model.IgnoreRule{}, nil
 }
 func (m mockStore) CreateJob(context.Context, storage.CreateJobParams) (model.Job, error) {
 	return model.Job{}, nil
@@ -84,7 +94,11 @@ func (applicationDetailsStore) ListSuppressedFindingsByApplication(context.Conte
 	return []model.SuppressedFinding{{ID: "suppressed-1", FieldPath: "spec.replicas"}}, nil
 }
 
-func TestGetApplicationIncludesSuppressedFindings(t *testing.T) {
+func (applicationDetailsStore) ListIgnoreRulesForApplication(context.Context, string, string) ([]model.IgnoreRule, error) {
+	return []model.IgnoreRule{{ID: "rule-1", MatchExpression: "spec.replicas"}}, nil
+}
+
+func TestGetApplicationIncludesSuppressionsAndIgnoreRules(t *testing.T) {
 	s := NewServer(applicationDetailsStore{}, mockQueue{}, slog.Default(), "", false)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/applications/application-1", nil)
 	rec := httptest.NewRecorder()
@@ -103,5 +117,69 @@ func TestGetApplicationIncludesSuppressedFindings(t *testing.T) {
 	}
 	if len(response.Data.Suppressions) != 1 || response.Data.Suppressions[0].ID != "suppressed-1" {
 		t.Fatalf("expected suppression audit record in application response, got %#v", response.Data.Suppressions)
+	}
+	if len(response.Data.IgnoreRules) != 1 || response.Data.IgnoreRules[0].ID != "rule-1" {
+		t.Fatalf("expected ignore rule in application response, got %#v", response.Data.IgnoreRules)
+	}
+}
+
+type ignoreRuleMutationStore struct {
+	mockStore
+	created storage.CreateIgnoreRuleParams
+	ruleID  string
+	active  bool
+}
+
+func (ignoreRuleMutationStore) GetApplicationByID(context.Context, string) (model.Application, error) {
+	return model.Application{ID: "application-1", WorkspaceID: "workspace-1"}, nil
+}
+
+func (s *ignoreRuleMutationStore) CreateIgnoreRule(_ context.Context, params storage.CreateIgnoreRuleParams) (model.IgnoreRule, error) {
+	s.created = params
+	return model.IgnoreRule{ID: "rule-1", ApplicationID: params.ApplicationID, Active: true}, nil
+}
+
+func (s *ignoreRuleMutationStore) SetIgnoreRuleActiveForApplication(_ context.Context, ruleID, applicationID string, active bool) (model.IgnoreRule, error) {
+	s.ruleID = ruleID
+	s.active = active
+	return model.IgnoreRule{ID: ruleID, ApplicationID: applicationID, Active: active}, nil
+}
+
+func TestCreateIgnoreRuleScopesRuleToApplicationAndActor(t *testing.T) {
+	store := &ignoreRuleMutationStore{}
+	s := NewServer(store, mockQueue{}, slog.Default(), "", true)
+	body := bytes.NewBufferString(`{"name":"  HPA replicas ","match_expression":" spec.replicas ","resource_ref":" apps/v1/Deployment:payments/ledger-api ","reason":" autoscaler "}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/applications/application-1/ignore-rules", body)
+	req.Header.Set("X-User-ID", "user-1")
+	req.Header.Set("X-Workspace-ID", "workspace-1")
+	rec := httptest.NewRecorder()
+
+	s.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, rec.Code)
+	}
+	if store.created.ApplicationID != "application-1" || store.created.WorkspaceID != "workspace-1" {
+		t.Fatalf("expected application-scoped rule, got %#v", store.created)
+	}
+	if store.created.CreatedBy != "user-1" || store.created.MatchExpression != "spec.replicas" ||
+		store.created.ResourceRef != "apps/v1/Deployment:payments/ledger-api" {
+		t.Fatalf("unexpected create parameters: %#v", store.created)
+	}
+}
+
+func TestSetIgnoreRuleActiveTargetsApplicationOwnedRule(t *testing.T) {
+	store := &ignoreRuleMutationStore{}
+	s := NewServer(store, mockQueue{}, slog.Default(), "", false)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/applications/application-1/ignore-rules/rule-1", bytes.NewBufferString(`{"active":false}`))
+	rec := httptest.NewRecorder()
+
+	s.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if store.ruleID != "rule-1" || store.active {
+		t.Fatalf("expected rule to be disabled, got id=%q active=%t", store.ruleID, store.active)
 	}
 }

--- a/internal/ignorerules/evaluator.go
+++ b/internal/ignorerules/evaluator.go
@@ -8,13 +8,14 @@ import (
 
 // Evaluator identifies the first persisted rule that suppresses a drift field.
 type Evaluator interface {
-	FindMatch(rules []model.IgnoreRule, fieldPath string) (model.IgnoreRule, bool)
+	FindMatch(rules []model.IgnoreRule, resourceRef, fieldPath string) (model.IgnoreRule, bool)
 }
 
-// ExactFieldPathEvaluator matches a rule expression to one canonical drift field path.
+// ExactFieldPathEvaluator matches canonical drift fields and optional exact resources.
 type ExactFieldPathEvaluator struct{}
 
-func (ExactFieldPathEvaluator) FindMatch(rules []model.IgnoreRule, fieldPath string) (model.IgnoreRule, bool) {
+func (ExactFieldPathEvaluator) FindMatch(rules []model.IgnoreRule, resourceRef, fieldPath string) (model.IgnoreRule, bool) {
+	resourceRef = strings.TrimSpace(resourceRef)
 	fieldPath = strings.TrimSpace(fieldPath)
 	if fieldPath == "" {
 		return model.IgnoreRule{}, false
@@ -22,6 +23,10 @@ func (ExactFieldPathEvaluator) FindMatch(rules []model.IgnoreRule, fieldPath str
 
 	for _, rule := range rules {
 		if !rule.Active {
+			continue
+		}
+		ruleResourceRef := strings.TrimSpace(rule.ResourceRef)
+		if ruleResourceRef != "" && ruleResourceRef != resourceRef {
 			continue
 		}
 		if strings.TrimSpace(rule.MatchExpression) == fieldPath {

--- a/internal/ignorerules/evaluator_test.go
+++ b/internal/ignorerules/evaluator_test.go
@@ -15,7 +15,7 @@ func TestExactFieldPathEvaluatorFindMatch(t *testing.T) {
 		{ID: "later-replicas", MatchExpression: "spec.replicas", Active: true},
 	}
 
-	rule, matched := evaluator.FindMatch(rules, "spec.replicas")
+	rule, matched := evaluator.FindMatch(rules, "apps/v1/Deployment:payments/ledger-api", "spec.replicas")
 	if !matched {
 		t.Fatal("expected exact field path match")
 	}
@@ -28,8 +28,26 @@ func TestExactFieldPathEvaluatorRejectsPartialMatch(t *testing.T) {
 	evaluator := ExactFieldPathEvaluator{}
 	rules := []model.IgnoreRule{{ID: "annotation", MatchExpression: "metadata.annotations", Active: true}}
 
-	_, matched := evaluator.FindMatch(rules, "metadata.annotations.rollout")
+	_, matched := evaluator.FindMatch(rules, "", "metadata.annotations.rollout")
 	if matched {
 		t.Fatal("expected partial expression not to suppress a field")
+	}
+}
+
+func TestExactFieldPathEvaluatorRequiresExactScopedResource(t *testing.T) {
+	evaluator := ExactFieldPathEvaluator{}
+	rules := []model.IgnoreRule{
+		{ID: "other-deployment", ResourceRef: "apps/v1/Deployment:payments/risk-api", MatchExpression: "spec.replicas", Active: true},
+		{ID: "application-wide", MatchExpression: "spec.replicas", Active: true},
+	}
+
+	rule, matched := evaluator.FindMatch(rules, "apps/v1/Deployment:payments/ledger-api", "spec.replicas")
+	if !matched || rule.ID != "application-wide" {
+		t.Fatalf("expected unmatched resource rule to be skipped, got %#v, %t", rule, matched)
+	}
+
+	rule, matched = evaluator.FindMatch(rules, "apps/v1/Deployment:payments/risk-api", "spec.replicas")
+	if !matched || rule.ID != "other-deployment" {
+		t.Fatalf("expected exact scoped resource match, got %#v, %t", rule, matched)
 	}
 }

--- a/internal/jobs/processor.go
+++ b/internal/jobs/processor.go
@@ -26,7 +26,7 @@ type Store interface {
 	GetApplicationByID(ctx context.Context, id string) (model.Application, error)
 	GetSourceDefinitionByID(ctx context.Context, id string) (model.SourceDefinition, error)
 	GetClusterByID(ctx context.Context, id string) (model.Cluster, error)
-	ListActiveIgnoreRulesByWorkspace(ctx context.Context, workspaceID string) ([]model.IgnoreRule, error)
+	ListActiveIgnoreRulesForAnalysis(ctx context.Context, workspaceID, applicationID string) ([]model.IgnoreRule, error)
 	CreateDesiredSnapshot(ctx context.Context, params storage.CreateDesiredSnapshotParams) (model.DesiredSnapshot, error)
 	CreateLiveSnapshot(ctx context.Context, params storage.CreateLiveSnapshotParams) (model.LiveSnapshot, error)
 	CreateIncident(ctx context.Context, params storage.CreateIncidentParams) (model.DriftIncident, error)
@@ -181,14 +181,14 @@ func (p *Processor) processAnalyze(ctx context.Context, msg Message) error {
 
 	var rules []model.IgnoreRule
 	if len(candidates) > 0 {
-		rules, err = p.store.ListActiveIgnoreRulesByWorkspace(ctx, app.WorkspaceID)
+		rules, err = p.store.ListActiveIgnoreRulesForAnalysis(ctx, app.WorkspaceID, app.ID)
 		if err != nil {
 			return fmt.Errorf("list active ignore rules: %w", err)
 		}
 	}
 
 	for _, candidate := range candidates {
-		rule, ignored := p.ignoreEvaluator.FindMatch(rules, candidate.FieldPath)
+		rule, ignored := p.ignoreEvaluator.FindMatch(rules, candidate.ResourceRef, candidate.FieldPath)
 		if ignored {
 			_, err = p.store.CreateSuppressedFinding(ctx, storage.CreateSuppressedFindingParams{
 				ApplicationID:     app.ID,

--- a/internal/jobs/processor_ignore_rules_test.go
+++ b/internal/jobs/processor_ignore_rules_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/AnouarMohamed/StateSight/pkg/model"
 )
 
-func TestProcessAnalyzeSuppressesCandidateMatchingWorkspaceIgnoreRule(t *testing.T) {
+func TestProcessAnalyzeSuppressesCandidateMatchingEffectiveIgnoreRule(t *testing.T) {
 	store := &ignoreRuleAnalysisStore{
 		app: model.Application{
 			ID:                 "application-1",
@@ -25,6 +25,8 @@ func TestProcessAnalyzeSuppressesCandidateMatchingWorkspaceIgnoreRule(t *testing
 		},
 		rules: []model.IgnoreRule{{
 			ID:              "rule-1",
+			ApplicationID:   "application-1",
+			ResourceRef:     "apps/v1/Deployment:payments/ledger-api",
 			Name:            "Allow HPA replica variance",
 			MatchExpression: "spec.replicas",
 			Reason:          "replicas are managed outside Git",
@@ -40,8 +42,9 @@ func TestProcessAnalyzeSuppressesCandidateMatchingWorkspaceIgnoreRule(t *testing
 		t.Fatalf("process analysis: %v", err)
 	}
 
-	if store.rulesWorkspaceID != store.app.WorkspaceID {
-		t.Fatalf("expected rule lookup for workspace %q, got %q", store.app.WorkspaceID, store.rulesWorkspaceID)
+	if store.rulesWorkspaceID != store.app.WorkspaceID || store.rulesApplicationID != store.app.ID {
+		t.Fatalf("expected rule lookup for workspace/application %q/%q, got %q/%q",
+			store.app.WorkspaceID, store.app.ID, store.rulesWorkspaceID, store.rulesApplicationID)
 	}
 	if store.rulesQueries != 1 {
 		t.Fatalf("expected one rule query per analysis, got %d", store.rulesQueries)
@@ -130,6 +133,7 @@ type ignoreRuleAnalysisStore struct {
 	app                     model.Application
 	rules                   []model.IgnoreRule
 	rulesWorkspaceID        string
+	rulesApplicationID      string
 	rulesQueries            int
 	desiredSnapshotsCreated int
 	liveSnapshotsCreated    int
@@ -156,9 +160,10 @@ func (*ignoreRuleAnalysisStore) GetClusterByID(context.Context, string) (model.C
 	return model.Cluster{}, nil
 }
 
-func (s *ignoreRuleAnalysisStore) ListActiveIgnoreRulesByWorkspace(_ context.Context, workspaceID string) ([]model.IgnoreRule, error) {
+func (s *ignoreRuleAnalysisStore) ListActiveIgnoreRulesForAnalysis(_ context.Context, workspaceID, applicationID string) ([]model.IgnoreRule, error) {
 	s.rulesQueries++
 	s.rulesWorkspaceID = workspaceID
+	s.rulesApplicationID = applicationID
 	return s.rules, nil
 }
 

--- a/internal/storage/ignore_rules.go
+++ b/internal/storage/ignore_rules.go
@@ -4,41 +4,115 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/AnouarMohamed/StateSight/pkg/model"
 )
 
-func (r *Repository) ListActiveIgnoreRulesByWorkspace(ctx context.Context, workspaceID string) ([]model.IgnoreRule, error) {
+func (r *Repository) ListActiveIgnoreRulesForAnalysis(ctx context.Context, workspaceID, applicationID string) ([]model.IgnoreRule, error) {
 	const query = `
-		SELECT id, workspace_id, name, match_expression, reason, created_by, active, created_at
+		SELECT id, workspace_id, COALESCE(application_id::text, ''), COALESCE(resource_ref, ''),
+			name, match_expression, reason, created_by, active, created_at
 		FROM ignore_rules
-		WHERE workspace_id = $1 AND active = TRUE
-		ORDER BY created_at ASC, id ASC
+		WHERE workspace_id = $1
+			AND (application_id IS NULL OR application_id = $2)
+			AND active = TRUE
+		ORDER BY (application_id IS NOT NULL) DESC, (resource_ref IS NOT NULL) DESC, created_at ASC, id ASC
 	`
 
-	rows, err := r.pool.Query(ctx, query, workspaceID)
+	rules, err := r.collectIgnoreRules(ctx, query, workspaceID, applicationID)
 	if err != nil {
-		return nil, fmt.Errorf("list active ignore rules by workspace: %w", err)
+		return nil, fmt.Errorf("list active ignore rules for analysis: %w", err)
+	}
+	return rules, nil
+}
+
+func (r *Repository) ListIgnoreRulesForApplication(ctx context.Context, workspaceID, applicationID string) ([]model.IgnoreRule, error) {
+	const query = `
+		SELECT id, workspace_id, COALESCE(application_id::text, ''), COALESCE(resource_ref, ''),
+			name, match_expression, reason, created_by, active, created_at
+		FROM ignore_rules
+		WHERE workspace_id = $1
+			AND (application_id IS NULL OR application_id = $2)
+		ORDER BY (application_id IS NOT NULL) DESC, (resource_ref IS NOT NULL) DESC, active DESC, created_at ASC, id ASC
+	`
+
+	rules, err := r.collectIgnoreRules(ctx, query, workspaceID, applicationID)
+	if err != nil {
+		return nil, fmt.Errorf("list ignore rules for application: %w", err)
+	}
+	return rules, nil
+}
+
+func (r *Repository) CreateIgnoreRule(ctx context.Context, params CreateIgnoreRuleParams) (model.IgnoreRule, error) {
+	const query = `
+		INSERT INTO ignore_rules (
+			id, workspace_id, application_id, resource_ref, name, match_expression, reason, created_by
+		) VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8)
+		RETURNING id, workspace_id, application_id::text, COALESCE(resource_ref, ''),
+			name, match_expression, reason, created_by, active, created_at
+	`
+
+	rule, err := scanIgnoreRule(r.pool.QueryRow(
+		ctx,
+		query,
+		uuid.NewString(),
+		params.WorkspaceID,
+		params.ApplicationID,
+		params.ResourceRef,
+		params.Name,
+		params.MatchExpression,
+		params.Reason,
+		params.CreatedBy,
+	))
+	if err != nil {
+		return model.IgnoreRule{}, mapConflict(fmt.Errorf("create ignore rule: %w", err))
+	}
+	return rule, nil
+}
+
+func (r *Repository) SetIgnoreRuleActiveForApplication(ctx context.Context, id, applicationID string, active bool) (model.IgnoreRule, error) {
+	const query = `
+		UPDATE ignore_rules
+		SET active = $3
+		WHERE id = $1 AND application_id = $2
+		RETURNING id, workspace_id, application_id::text, COALESCE(resource_ref, ''),
+			name, match_expression, reason, created_by, active, created_at
+	`
+
+	rule, err := scanIgnoreRule(r.pool.QueryRow(ctx, query, id, applicationID, active))
+	if err != nil {
+		return model.IgnoreRule{}, mapNotFound(fmt.Errorf("set application ignore rule active: %w", err))
+	}
+	return rule, nil
+}
+
+func (r *Repository) collectIgnoreRules(ctx context.Context, query string, args ...any) ([]model.IgnoreRule, error) {
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
 	}
 	defer rows.Close()
 
-	rules, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (model.IgnoreRule, error) {
-		var rule model.IgnoreRule
-		err := row.Scan(
-			&rule.ID,
-			&rule.WorkspaceID,
-			&rule.Name,
-			&rule.MatchExpression,
-			&rule.Reason,
-			&rule.CreatedBy,
-			&rule.Active,
-			&rule.CreatedAt,
-		)
-		return rule, err
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (model.IgnoreRule, error) {
+		return scanIgnoreRule(row)
 	})
-	if err != nil {
-		return nil, fmt.Errorf("scan active ignore rules by workspace: %w", err)
-	}
-	return rules, nil
+}
+
+func scanIgnoreRule(row interface{ Scan(...any) error }) (model.IgnoreRule, error) {
+	var rule model.IgnoreRule
+	err := row.Scan(
+		&rule.ID,
+		&rule.WorkspaceID,
+		&rule.ApplicationID,
+		&rule.ResourceRef,
+		&rule.Name,
+		&rule.MatchExpression,
+		&rule.Reason,
+		&rule.CreatedBy,
+		&rule.Active,
+		&rule.CreatedAt,
+	)
+	return rule, err
 }

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-var ErrNotFound = errors.New("resource not found")
+var (
+	ErrConflict = errors.New("resource conflict")
+	ErrNotFound = errors.New("resource not found")
+)
 
 type Repository struct {
 	pool *pgxpool.Pool
@@ -29,6 +33,14 @@ func (r *Repository) Ping(ctx context.Context) error {
 func mapNotFound(err error) error {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrNotFound
+	}
+	return err
+}
+
+func mapConflict(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return ErrConflict
 	}
 	return err
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -72,6 +72,16 @@ type CreateSuppressedFindingParams struct {
 	DifferenceType    string
 }
 
+type CreateIgnoreRuleParams struct {
+	WorkspaceID     string
+	ApplicationID   string
+	ResourceRef     string
+	Name            string
+	MatchExpression string
+	Reason          string
+	CreatedBy       string
+}
+
 type UpsertGitHubEventParams struct {
 	EventType  string
 	DeliveryID string

--- a/migrations/0006_scoped_ignore_rules.sql
+++ b/migrations/0006_scoped_ignore_rules.sql
@@ -1,0 +1,30 @@
+ALTER TABLE ignore_rules
+    ADD COLUMN IF NOT EXISTS application_id UUID REFERENCES applications(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS resource_ref TEXT NULL;
+
+ALTER TABLE ignore_rules
+    DROP CONSTRAINT IF EXISTS chk_ignore_rules_resource_scope;
+
+ALTER TABLE ignore_rules
+    ADD CONSTRAINT chk_ignore_rules_resource_scope
+    CHECK (resource_ref IS NULL OR application_id IS NOT NULL);
+
+ALTER TABLE ignore_rules
+    DROP CONSTRAINT IF EXISTS ignore_rules_workspace_id_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ignore_rules_workspace_name
+    ON ignore_rules (workspace_id, name)
+    WHERE application_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ignore_rules_application_name
+    ON ignore_rules (application_id, name)
+    WHERE application_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_ignore_rules_workspace_active;
+
+CREATE INDEX IF NOT EXISTS idx_ignore_rules_analysis_active
+    ON ignore_rules (workspace_id, application_id, created_at, id)
+    WHERE active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_ignore_rules_application
+    ON ignore_rules (workspace_id, application_id, active, created_at, id);

--- a/pkg/model/ignore_rule.go
+++ b/pkg/model/ignore_rule.go
@@ -6,6 +6,8 @@ import "time"
 type IgnoreRule struct {
 	ID              string    `json:"id"`
 	WorkspaceID     string    `json:"workspace_id"`
+	ApplicationID   string    `json:"application_id"`
+	ResourceRef     string    `json:"resource_ref"`
 	Name            string    `json:"name"`
 	MatchExpression string    `json:"match_expression"`
 	Reason          string    `json:"reason"`


### PR DESCRIPTION
## Summary

- add application-scoped ignore rules with optional exact resource matching
- expose rule creation and activation controls in the application API and UI
- retain existing workspace rules as inherited, read-only effective rules
- fix local and Docker Compose web API routing through the Vite proxy
- document rule precedence, compatibility behavior, and current limitations

## Why

Ignore-rule evaluation was previously limited to workspace-wide field-path suppression. That is too broad for routine operator use because suppressing expected drift for one application can hide the same field on unrelated applications.

The application UI also relied on an API base URL configuration that bypassed the existing Vite proxy in browser usage, preventing the documented local-stack workflow from reliably exercising API-backed controls.

## Behavior

- API/UI-created rules are scoped to one application.
- A managed rule may optionally match one exact `resource_ref`.
- Resource-scoped application rules are evaluated before application-wide rules.
- Existing rules without an `application_id` remain inherited workspace rules for backwards compatibility.
- Inherited rules are displayed in application details but cannot be enabled or disabled through the application management route.
- Suppressed findings continue to be persisted as audit records with captured rule metadata.

## Implementation

- add `application_id` and `resource_ref` scope fields to `ignore_rules`
- add indexes and uniqueness rules for inherited workspace names and per-application managed names
- update worker rule loading and matching precedence
- add create and activation-update endpoints for application-owned ignore rules
- include effective ignore rules in application detail responses
- add an `Ignore Rules` tab with create and enable/disable controls
- configure local and Compose web development to use the Vite API proxy correctly
- update README, architecture, roadmap, and decision documentation

## Verification

- `make test`
- `make lint`
- `make docs-check`
- `docker compose config --quiet`
- `cd apps/web && npm run build`
- `git diff --check origin/main...HEAD`
- applied migrations through `0006` against fresh PostgreSQL
- verified per-application rule-name uniqueness and cross-application reuse
- verified API create, list, disable, inherited-rule rejection, and duplicate-conflict behavior
- verified frontend API access through the Vite proxy

## Follow-Up

- add edit and deletion flows for application-owned rules
- define deliberate administration for workspace-wide inherited rules
- replace placeholder evidence attribution with real provenance signals